### PR TITLE
Fastai Food-101 Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ Trains a fashion mnist classifier with a small CNN using the pytorch framework.
 cd examples/pytorch-cnn-fashion
 python train.py
 ```
+### fastai-food101
+Trains a 121 layer DenseNet on the [Food-101 dataset](https://www.vision.ee.ethz.ch/datasets_extra/food-101/) using the 1cycle learning rate policy, mixed precision training, mixup data augmentation, and progressive resizing.
+```
+cd fastai/food-101
+pip install -r requirements.txt
+python train.py
+```
 
 ### fastai-unet-segmentation
 

--- a/fastai-food101/requirements.txt
+++ b/fastai-food101/requirements.txt
@@ -1,0 +1,2 @@
+fastai
+wandb

--- a/fastai-food101/train.py
+++ b/fastai-food101/train.py
@@ -1,0 +1,26 @@
+from fastai import *
+from fastai.vision import *
+
+import wandb
+from wandb.fastai import WandbCallback
+wandb.init()
+
+path = untar_data("https://s3.amazonaws.com/fast-ai-imageclas/food-101")
+
+tfms = get_transforms()
+data = ImageDataBunch.from_folder(path, train='images', valid_pct = 0.25, bs = 128, ds_tfms = tfms, size = 224)
+
+learn = cnn_learner(data, models.densenet121, metrics=[accuracy, top_k_accuracy], callback_fns=partial(WandbCallback, input_type='images')).mixup().to_fp16()
+
+learn.fit_one_cycle(3)
+
+learn.unfreeze()
+learn.fit_one_cycle(10)
+
+learn.save('stage-1')
+
+data = data = ImageDataBunch.from_folder(path, train='images', valid_pct = 0.25, ds_tfms = tfms, size = 512)
+
+learn.load('stage-1')
+learn.unfreeze()
+learn.fit_one_cycle(10)

--- a/fastai-food101/train.py
+++ b/fastai-food101/train.py
@@ -3,7 +3,7 @@ from fastai.vision import *
 
 import wandb
 from wandb.fastai import WandbCallback
-wandb.init()
+wandb.init(project="fastai-food-101", entity="wandb-examples")
 
 path = untar_data("https://s3.amazonaws.com/fast-ai-imageclas/food-101")
 


### PR DESCRIPTION
This PR adds an example script that trains a 121 layer DenseNet on the [Food-101 dataset ](https://www.vision.ee.ethz.ch/datasets_extra/food-101/) using fastai.

The script uses a variety of training techniques, including but not limited to progressive resizing, mixup data augmentation, mixed-precision training for Nvidia Volta GPUs, etc.

Surprisingly, the model obtains ~85% accuracy with this simple script that totals less than 20 lines of code. All results are logged to Weights & Biases for analysis.