### PR TITLE
Adds Intro colab; fixes whitespace and .finish

### DIFF
--- a/colabs/intro/Intro_to_Weights_&_Biases.ipynb
+++ b/colabs/intro/Intro_to_Weights_&_Biases.ipynb
@@ -1,0 +1,364 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "Copy of Intro to Weights & Biases",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [],
+      "toc_visible": true,
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/wandb/examples/blob/cf%2Fadd-intro-colab/colabs/intro/Intro_to_Weights_%26_Biases.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "astzjdx3ZG3b",
+        "colab_type": "text"
+      },
+      "source": [
+        "<img src=\"https://i.imgur.com/gb6B4ig.png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+        "\n",
+        "# Quickstart\n",
+        "Use Weights & Biases for machine learning experiment tracking, dataset versioning, and project collaboration.\n",
+        "\n",
+        "<div><img /></div>\n",
+        "\n",
+        "<img src=\"https://i.imgur.com/uEtWSEb.png\" width=\"650\" alt=\"Weights & Biases\" />\n",
+        "\n",
+        "<div><img /></div>\n",
+        "\n",
+        "## Data & Privacy\n",
+        "We take security very seriously, and our cloud-hosted dashboard uses industry standard best practices for encryption. If you're working with datasets that cannot leave your enterprise cluster, we have [on-prem](https://docs.wandb.com/self-hosted) installations available. \n",
+        "\n",
+        "It's also easy to download all your data and export it to other tools— like custom analysis in a Jupyter notebook. Here's more on our [API](https://docs.wandb.com/library/api).\n",
+        "\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bREQhiEzpGZ5",
+        "colab_type": "text"
+      },
+      "source": [
+        "Start by installing the library and logging in to your free account."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "wRsHBj-EpDHd",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "%%capture\n",
+        "!pip install wandb -qqq\n",
+        "import wandb"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "6vrgcv66ypoj",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "!wandb login"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "8moOgk_Dpegd",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Run your first W&B experiment\n",
+        "1. Start a new run and pass in hyperparameters to track\n",
+        "2. Log metrics from training or evaluation\n",
+        "3. Visualize results in the dashboard"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "-VE3MabfZAcx",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "import math\n",
+        "import random\n",
+        "\n",
+        "# Start a new run, tracking config metadata\n",
+        "wandb.init(project=\"test-drive\", config={\n",
+        "    \"learning_rate\": 0.02,\n",
+        "    \"dropout\": 0.2,\n",
+        "    \"architecture\": \"CNN\",\n",
+        "    \"dataset\": \"CIFAR-100\",\n",
+        "})\n",
+        "config = wandb.config\n",
+        "\n",
+        "# Simulating a training or evaluation loop\n",
+        "for x in range(50):\n",
+        "    acc = math.log(1 + x + random.random() * config.learning_rate) + random.random()\n",
+        "    loss = 10 - math.log(1 + x + random.random() + config.learning_rate * x) + random.random()\n",
+        "    # Log metrics from your script to W&B\n",
+        "    wandb.log({\"acc\":acc, \"loss\":loss})\n",
+        "\n",
+        "wandb.finish()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ApRtY4ZFt_su",
+        "colab_type": "text"
+      },
+      "source": [
+        "Here's an example of what an interactive dashboard looks like in W&B.\n",
+        "![](https://i.imgur.com/4I51OuT.png)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "VIwkQ8QC3JZU",
+        "colab_type": "text"
+      },
+      "source": [
+        "# Example Model\n",
+        "Train a quick model in Keras and track results with W&B. Check our [examples repo](https://github.com/wandb/examples) for scripts using Keras, PyTorch, TensorFlow, Scikit, XGBoost and more."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Ja6PVWTT_77U",
+        "colab_type": "text"
+      },
+      "source": [
+        "## 1- Simple Keras CNN\n",
+        "Run this model to train a simple MNIST classifier, and click on the project page link to see your results stream in live to a W&B project."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "8yrgPBRXrvx2",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Simple Keras Model\n",
+        "\n",
+        "import tensorflow as tf\n",
+        "from tensorflow.keras.callbacks import Callback\n",
+        "from wandb.keras import WandbCallback\n",
+        "\n",
+        "# Set an experiment name to group training and evaluation\n",
+        "experiment_name = wandb.util.generate_id()\n",
+        "\n",
+        "# Start a run, tracking hyperparameters\n",
+        "wandb.init(\n",
+        "    project=\"intro-demo\",\n",
+        "    group=experiment_name,\n",
+        "    config={\n",
+        "        \"layer_1\": 512,\n",
+        "        \"activation_1\": \"relu\",\n",
+        "        \"dropout\": 0.2,\n",
+        "        \"layer_2\": 10,\n",
+        "        \"activation_2\": \"softmax\",\n",
+        "        \"optimizer\": \"sgd\",\n",
+        "        \"loss\": \"sparse_categorical_crossentropy\",\n",
+        "        \"metric\": \"accuracy\",\n",
+        "        \"epoch\": 6,\n",
+        "        \"batch_size\": 32\n",
+        "    })\n",
+        "config = wandb.config\n",
+        "\n",
+        "# Get the data\n",
+        "mnist = tf.keras.datasets.mnist\n",
+        "(x_train, y_train), (x_test, y_test) = mnist.load_data()\n",
+        "x_train, x_test = x_train / 255.0, x_test / 255.0\n",
+        "x_train, y_train = x_train[::5], y_train[::5]  # Subset data for a faster demo\n",
+        "\n",
+        "# Build a model\n",
+        "model = tf.keras.models.Sequential([\n",
+        "    tf.keras.layers.Flatten(input_shape=(28, 28)),\n",
+        "    tf.keras.layers.Dense(config.layer_1, activation=config.activation_1),\n",
+        "    tf.keras.layers.Dropout(config.dropout),\n",
+        "    tf.keras.layers.Dense(config.layer_2, activation=config.activation_2)\n",
+        "    ])\n",
+        "\n",
+        "model.compile(optimizer=config.optimizer,\n",
+        "              loss=config.loss,\n",
+        "              metrics=[config.metric]\n",
+        "              )\n",
+        "\n",
+        "history = model.fit(x=x_train,\n",
+        "                    y=y_train,\n",
+        "                    epochs=config.epoch,\n",
+        "                    batch_size=config.batch_size,\n",
+        "                    validation_data=(x_test, y_test),\n",
+        "                    # Use the WandbCallback to automatically save all the\n",
+        "                    # metrics tracked in model.fit() to your dashboard\n",
+        "                    callbacks=[WandbCallback()]\n",
+        "                    )\n",
+        "\n",
+        "wandb.finish()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BCnytQce3ANg",
+        "colab_type": "text"
+      },
+      "source": [
+        "## 2- Log Analysis\n",
+        "\n",
+        "Next, log an analysis run, using the same experiment name as the `group` parameter so that this run and the previous run are grouped together in W&B."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Fz-aJp3q3T4r",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "%%capture\n",
+        "# Install dependencies\n",
+        "!pip install scikit-plot -qqq"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "x6keMBLFzdnp",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "import numpy as np\n",
+        "from sklearn.metrics import f1_score\n",
+        "import matplotlib.pyplot as plt\n",
+        "from scikitplot.metrics import plot_confusion_matrix, plot_roc\n",
+        "\n",
+        "wandb.init(project=\"intro-demo\", group=experiment_name)\n",
+        "\n",
+        "# Log F1 Score\n",
+        "y_test_pred = np.asarray(model.predict(x_test))\n",
+        "y_test_pred_class = np.argmax(y_test_pred, axis=1)\n",
+        "f1 = f1_score(y_test, y_test_pred_class, average='micro')\n",
+        "wandb.log({\"f1\": f1},\n",
+        "          commit=False)  # Hold on, more incoming!\n",
+        "\n",
+        "# Log Confusion Matrix\n",
+        "fig, ax = plt.subplots(figsize=(16, 12))\n",
+        "plot_confusion_matrix(y_test, y_test_pred_class, ax=ax)\n",
+        "wandb.log({\"confusion_matrix\": wandb.Image(fig)}, commit=False)\n",
+        "\n",
+        "# Log ROC Curve\n",
+        "fig, ax = plt.subplots(figsize=(16, 12))\n",
+        "plot_roc(y_test, y_test_pred, ax=ax)\n",
+        "wandb.log({\"plot_roc\": wandb.Image(fig)},\n",
+        "          commit=True)  # Now we've logged everything for this step\n",
+        "\n",
+        "class_score_data = []\n",
+        "for test, pred in zip(y_test, y_test_pred):\n",
+        "    class_score_data.append([test, pred])\n",
+        "\n",
+        "wandb.log({\"class_scores\": wandb.Table(data=class_score_data,\n",
+        "                                           columns=[\"test\", \"pred\"])})"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "UUkXIEXtqLTJ",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "print(y_test)\n",
+        "print(y_test_pred)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "mfrYlY1N9vTl",
+        "colab_type": "text"
+      },
+      "source": [
+        "## 3- Visualize Results\n",
+        "\n",
+        "Click on the **project page** link above to see your live results.\n",
+        "\n",
+        "## 4- Example Gallery\n",
+        "\n",
+        "See examples of projects tracked and visualized with W&B in our [Gallery →](https://app.wandb.ai/gallery)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "XAdq9OcVhTcE",
+        "colab_type": "text"
+      },
+      "source": [
+        "# Best Practices\n",
+        "\n",
+        "1. **Projects**: Log multiple runs to a project to compare them. `wandb.init(project=\"project-name\")`\n",
+        "2. **Groups**: For multiple processes or cross validation folds, log each process as a runs and group them together. `wandb.init(group='experiment-1')`\n",
+        "3. **Tags**: Add tags to track your current baseline or production model.\n",
+        "4. **Notes**: Type notes in the table to track the changes between runs.\n",
+        "5. **Reports**: Take quick notes on progress to share with colleagues and make dashboards and snapshots of your ML projects.\n",
+        "\n",
+        "### Advanced Setup\n",
+        "1. [Environment variables](https://docs.wandb.com/library/environment-variables): Set API keys in environment variables so you can run training on a managed cluster.\n",
+        "2. [Offline mode](https://docs.wandb.com/library/technical-faq#can-i-run-wandb-offline): Use `dryrun` mode to train offline and sync results later.\n",
+        "3. [On-prem](https://docs.wandb.com/self-hosted): Install W&B in a private cloud or air-gapped servers in your own infrastructure. We have local installations for everyone from academics to enterprise teams.\n",
+        "4. [Sweeps](https://docs.wandb.com/sweeps): Set up hyperparameter search quickly with our lightweight tool for tuning.\n",
+        "5. [Artifacts](https://docs.wandb.com/artifacts): Track and version models and datasets in a streamlined way that automatically picks up your pipeline steps as you train models."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This branch demonstrates the process for adding Colabs outlined in #28.

Additionally, it makes the following changes to the Colab:

1. Unifies whitespace style: 4 spaces, instead of mixed 4 and 2.
2. Adds `%%capture`s to the installation cells. This is of debatable utility, since the notebook uses the private outputs feature, but I wanted to demonstrate it.
3. Adds `.finish` in between the two `.init` calls.
4. Adds a few comments.

@ayulockin, take a look.