### PR TITLE
Typo

### DIFF
--- a/colabs/wandb-artifacts/Pipeline_Versioning_with_W&B_Artifacts.ipynb
+++ b/colabs/wandb-artifacts/Pipeline_Versioning_with_W&B_Artifacts.ipynb
@@ -153,7 +153,7 @@
         "We start with the `Dataset`s:\n",
         "- a `train`ing set, for choosing the parameters,\n",
         "- a `validation` set, for choosing the hyperparameters,\n",
-        "- a `test`in set, for evaluating the final model\n",
+        "- a `test`ing set, for evaluating the final model\n",
         "\n",
         "The first cell below defines these three datasets."
       ]


### PR DESCRIPTION
A little typo.
Instead of `test`ing the notebook has `test`in.
