### PR TITLE
Minor updates to the streamlit example

### DIFF
--- a/examples/streamlit/wandb_streamlit_app.py
+++ b/examples/streamlit/wandb_streamlit_app.py
@@ -18,7 +18,6 @@ def main():
     height = 720
 
     projects = get_projects(entity, height=720)
-
     if menu_choice == 'Embed WANDB':
         st.subheader("WANDB IFrame test")
 
@@ -28,7 +27,7 @@ def main():
         selected_project = st.sidebar.selectbox(
             "Project Name", list(projects.keys()))
         selected_project_iframe = projects[selected_project]
-        st.text("Using the WANDB API we can directly query project and run page links which we can use to embed Iframes")
+        st.text_area("Using the WANDB API we can directly query project and run page links which we can use to embed Iframes")
         st.subheader("PROJECT DETAILS:")
         components.html(selected_project_iframe, height=height)
 
@@ -54,7 +53,6 @@ def main():
 
         selected_project = "Log-Example-HTML"
         if selected_project in projects:
-            selected_artifact = "demo_artifacts"
             selected_html_file_name = "demo_html"
 
             # We load the run from the api and then gather the artifacts to display

--- a/examples/streamlit/wandb_utils.py
+++ b/examples/streamlit/wandb_utils.py
@@ -62,23 +62,29 @@ def get_wandb_demo_artifact(project_path):
     return artifact_dir
 
 
-def save_webpage_to_html(url, dest_path="example.html"):
-    import urllib.request
-    import urllib.error
-    import urllib.parse
+def save_example_html(dest_path="example.html"):
 
-    response = urllib.request.urlopen(url)
-    content = response.read()
+    with open(dest_path, 'w') as f:
+        content = """
+        <!DOCTYPE html>
+        <html>
+        <body>
 
-    f = open(dest_path, 'wb')
-    f.write(content)
-    f.close
+        <h1 style="color:blue">Example HTML</h1>
+        <p style="color:blue">This HTML is logged and tracked as a W&B Artifact. 
+        You can log anything as a W&B Artifact including models & datasets and they will be tracked and versioned anytime you update them.
+        </p>
+
+        </body>
+        </html>
+        """
+        f.write(content)
 
 
 def log_example_html_to_wandb():
     run = wandb.init(project="Log-Example-HTML")
     dest_path = "example.html"
-    save_webpage_to_html(url="http://example.com", dest_path=dest_path)
+    save_example_html(dest_path=dest_path)
 
     demo_artifacts = wandb.Artifact("demo_artifacts", type="demo")
     demo_html = wandb.Html(dest_path)


### PR DESCRIPTION
I changed some of the descriptions in the README and gave instructions to find the API key and `entity`. 

I also changed the HTML page that is saved to use a locally written HTML page rather than the example.com webpage as this was causing errors. 