### PR TITLE
fix metric logging in PTL example

### DIFF
--- a/colabs/pytorch-lightning/Optimize_Pytorch_Lightning_models_with_Weights_&_Biases.ipynb
+++ b/colabs/pytorch-lightning/Optimize_Pytorch_Lightning_models_with_Weights_&_Biases.ipynb
@@ -71,7 +71,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -qqq pytorch-lightning wandb"
+        "!pip install -qU pytorch-lightning wandb"
       ]
     },
     {
@@ -226,7 +226,7 @@
         "        if stage in [None, 'fit', 'validate']:\n",
         "            mnist_train = MNIST(self.data_dir, train=True, transform=self.transform)\n",
         "            self.mnist_train, self.mnist_val = random_split(mnist_train, [55000, 5000])\n",
-        "        if stage == 'test' or stage is None:\n",
+        "        if stage in [None, 'test']:\n",
         "            self.mnist_test = MNIST(self.data_dir, train=False, transform=self.transform)\n",
         "\n",
         "    def train_dataloader(self):\n",
@@ -298,7 +298,7 @@
         "import torch\n",
         "from torch.nn import Linear, CrossEntropyLoss, functional as F\n",
         "from torch.optim import Adam\n",
-        "import torchmetrics\n",
+        "from torchmetrics.functional import accuracy\n",
         "from pytorch_lightning import LightningModule\n",
         "\n",
         "class MNIST_LitModule(LightningModule):\n",
@@ -317,9 +317,6 @@
         "\n",
         "        # optimizer parameters\n",
         "        self.lr = lr\n",
-        "\n",
-        "        # metrics\n",
-        "        self.accuracy = torchmetrics.Accuracy()\n",
         "\n",
         "        # save hyper-parameters to self.hparams (auto-logged by W&B)\n",
         "        self.save_hyperparameters()\n",
@@ -380,7 +377,7 @@
         "        logits = self(x)\n",
         "        preds = torch.argmax(logits, dim=1)\n",
         "        loss = self.loss(logits, y)\n",
-        "        acc = self.accuracy(preds, y)\n",
+        "        acc = accuracy(preds, y)\n",
         "        return preds, loss, acc"
       ]
     },


### PR DESCRIPTION
Modular metrics in `torchmetrics` contain a state which needs to be created separately for sub-task and reset at the epoch end if the instance isn't logged. Better use functional metrics here for simplicity.

More info here: https://torchmetrics.readthedocs.io/en/latest/pages/lightning.html