### PR TITLE
Fix typo in EXAMPLE-REQUEST.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/EXAMPLE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/EXAMPLE-REQUEST.yml
@@ -10,7 +10,7 @@ body:
     attributes:
       value: |
         Hello, are you trying to find something that is missing in the examples/documentation? Do you want to propose an example? Please tell us more about!
-        - You may find what you are looing for in our [forums](https://community.wandb.ai)
+        - You may find what you are looking for in our [forums](https://community.wandb.ai)
         - Or ping us on [twitter](https://twitter.com/weights_biases)
   - type: textarea
     id: request


### PR DESCRIPTION
![Screenshot from 2022-01-24 14-25-59](https://user-images.githubusercontent.com/71897199/150752590-5b4087de-e7f2-4683-a58c-5014940a66a9.png)
Hi, I noticed a little typo in the EXAMPLE-REQUEST template. Updated changes are shown in the image above.
"what you are looing for in our forums" -> "what you are looking for in our forums"

Question:
This is my first time contributing to open source. Should i have raised an issue first and then generated this PR or is it okay to not raise an issue if the change is small?