### PR TITLE
Fix sagemaker exception because of missing main func

### DIFF
--- a/examples/pytorch/pytorch-cifar10-sagemaker/source/cifar10.py
+++ b/examples/pytorch/pytorch-cifar10-sagemaker/source/cifar10.py
@@ -6,41 +6,6 @@ import os
 import json
 
 
-wandb.init(project="sm-pytorch-cifar")
-
-config = wandb.config
-# Set defaults if we dont have values from SageMaker
-if config.get('batch_size') is None:
-    config.batch_size = 20
-    config.lr = 0.001
-    config.momentum = 0.9
-    config.epochs = 10
-    config.hidden_nodes = 120
-    config.conv1_channels = 5
-    config.conv2_channels = 16
-
-
-########################################################################
-# The output of torchvision datasets are PILImage images of range [0, 1].
-# We transform them to Tensors of normalized range [-1, 1].
-
-transform = transforms.Compose(
-    [transforms.ToTensor(),
-     transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
-
-trainset = torchvision.datasets.CIFAR10(
-    os.getenv('SM_CHANNEL_TRAINING', 'data'), train=True, transform=transform)
-trainloader = torch.utils.data.DataLoader(trainset, batch_size=config.batch_size,
-                                          shuffle=True, num_workers=2)
-
-testset = torchvision.datasets.CIFAR10(
-    os.getenv('SM_CHANNEL_TRAINING', 'data'), train=False, transform=transform)
-testloader = torch.utils.data.DataLoader(testset, batch_size=config.batch_size,
-                                         shuffle=False, num_workers=2)
-
-classes = ('plane', 'car', 'bird', 'cat',
-           'deer', 'dog', 'frog', 'horse', 'ship', 'truck')
-
 import torch.nn as nn
 import torch.nn.functional as F
 
@@ -49,112 +14,152 @@ class Net(nn.Module):
     def __init__(self):
         super(Net, self).__init__()
         self.conv1 = nn.Conv2d(
-            3, config.conv1_channels, 5)
+            3, wandb.config.conv1_channels, 5)
         self.pool = nn.MaxPool2d(2, 2)
-        self.conv2 = nn.Conv2d(config.conv1_channels,
-                               config.conv2_channels, 5)
-        self.fc1 = nn.Linear(config.conv2_channels *
-                             5 * 5, config.hidden_nodes)
-        self.fc2 = nn.Linear(config.hidden_nodes, 84)
+        self.conv2 = nn.Conv2d(wandb.config.conv1_channels,
+                               wandb.config.conv2_channels, 5)
+        self.fc1 = nn.Linear(wandb.config.conv2_channels *
+                             5 * 5, wandb.config.hidden_nodes)
+        self.fc2 = nn.Linear(wandb.config.hidden_nodes, 84)
         self.fc3 = nn.Linear(84, 10)
 
     def forward(self, x):
         x = self.pool(F.relu(self.conv1(x)))
         x = self.pool(F.relu(self.conv2(x)))
-        x = x.view(-1, config.conv2_channels * 5 * 5)
+        x = x.view(-1, wandb.config.conv2_channels * 5 * 5)
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         x = self.fc3(x)
         return x
 
 
-net = Net()
-device = 'cuda' if torch.cuda.is_available() else 'cpu'
-net = net.to(device)
+def main():
+    wandb.init(project="sm-pytorch-cifar")
 
-wandb.watch(net)
+    config = wandb.config
+    # Set defaults if we dont have values from SageMaker
+    if config.get('batch_size') is None:
+        config.batch_size = 20
+        config.lr = 0.001
+        config.momentum = 0.9
+        config.epochs = 10
+        config.hidden_nodes = 120
+        config.conv1_channels = 5
+        config.conv2_channels = 16
 
-import torch.optim as optim
 
-criterion = nn.CrossEntropyLoss()
-optimizer = optim.SGD(net.parameters(), lr=float(
-    config.lr), momentum=config.momentum)
+    ########################################################################
+    # The output of torchvision datasets are PILImage images of range [0, 1].
+    # We transform them to Tensors of normalized range [-1, 1].
 
-# loop over the dataset multiple times
-for epoch in range(config.epochs):
+    transform = transforms.Compose(
+        [transforms.ToTensor(),
+        transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
 
-    running_loss = 0.0
-    for i, data in enumerate(trainloader, 0):
-        # get the inputs
-        inputs, labels = data
-        inputs, labels = inputs.to(device), labels.to(device)
+    trainset = torchvision.datasets.CIFAR10(
+        os.getenv('SM_CHANNEL_TRAINING', 'data'), train=True, transform=transform)
+    trainloader = torch.utils.data.DataLoader(trainset, batch_size=config.batch_size,
+                                          shuffle=True, num_workers=2)
 
-        # zero the parameter gradients
-        optimizer.zero_grad()
+    testset = torchvision.datasets.CIFAR10(
+        os.getenv('SM_CHANNEL_TRAINING', 'data'), train=False, transform=transform)
+    testloader = torch.utils.data.DataLoader(testset, batch_size=config.batch_size,
+                                         shuffle=False, num_workers=2)
 
-        # forward + backward + optimize
-        outputs = net(inputs)
-        loss = criterion(outputs, labels)
-        loss.backward()
-        optimizer.step()
+    classes = ('plane', 'car', 'bird', 'cat',
+            'deer', 'dog', 'frog', 'horse', 'ship', 'truck')
 
-        # print statistics
-        running_loss += loss.item()
-        if i % 2000 == 1999:    # print every 2000 mini-batches
-            print('[%d, %5d] loss: %.3f' %
-                  (epoch + 1, i + 1, running_loss / 2000))
-            running_loss = 0.0
+    net = Net()
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    net = net.to(device)
 
-    dataiter = iter(testloader)
-    images, labels = dataiter.next()
-    images, labels = images.to(device), labels.to(device)
+    wandb.watch(net)
 
-    outputs = net(images)
-    _, predicted = torch.max(outputs, 1)
+    import torch.optim as optim
 
-    example_images = [wandb.Image(image, caption=classes[predicted])
-                      for image, predicted, label in zip(images, predicted, labels)]
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.SGD(net.parameters(), lr=float(
+        config.lr), momentum=config.momentum)
 
-    # Let us look at how the network performs on the whole dataset.
+    # loop over the dataset multiple times
+    for epoch in range(config.epochs):
 
-    correct = 0
-    total = 0
-    with torch.no_grad():
-        for data in testloader:
-            images, labels = data
-            images, labels = images.to(device), labels.to(device)
+        running_loss = 0.0
+        for i, data in enumerate(trainloader, 0):
+            # get the inputs
+            inputs, labels = data
+            inputs, labels = inputs.to(device), labels.to(device)
 
-            outputs = net(images)
-            _, predicted = torch.max(outputs.data, 1)
-            total += labels.size(0)
-            correct += (predicted == labels).sum().item()
+            # zero the parameter gradients
+            optimizer.zero_grad()
 
-    test_acc = 100 * correct / total
+            # forward + backward + optimize
+            outputs = net(inputs)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
 
-    class_correct = list(0. for i in range(10))
-    class_total = list(0. for i in range(10))
-    with torch.no_grad():
-        for data in testloader:
-            images, labels = data
-            images, labels = images.to(device), labels.to(device)
+            # print statistics
+            running_loss += loss.item()
+            if i % 2000 == 1999:    # print every 2000 mini-batches
+                print('[%d, %5d] loss: %.3f' %
+                    (epoch + 1, i + 1, running_loss / 2000))
+                running_loss = 0.0
 
-            outputs = net(images)
-            _, predicted = torch.max(outputs, 1)
-            c = (predicted == labels).squeeze()
-            for i in range(4):
-                label = labels[i]
-                class_correct[label] += c[i].item()
-                class_total[label] += 1
+        dataiter = iter(testloader)
+        images, labels = dataiter.next()
+        images, labels = images.to(device), labels.to(device)
 
-    print("Test Accuracy: %.4f" % test_acc)
-    class_acc = {}
-    for i in range(10):
-        print('Accuracy of %5s : %2d %%' % (
-            classes[i], 100 * class_correct[i] / class_total[i]))
-        class_acc["Accuracy of %5s" %
-                  (classes[i])] = 100 * class_correct[i] / class_total[i]
+        outputs = net(images)
+        _, predicted = torch.max(outputs, 1)
 
-    wandb.log(class_acc, commit=False)
-    wandb.log({"Examples": example_images,
+        example_images = [wandb.Image(image, caption=classes[predicted])
+                        for image, predicted, label in zip(images, predicted, labels)]
+
+        # Let us look at how the network performs on the whole dataset.
+
+        correct = 0
+        total = 0
+        with torch.no_grad():
+            for data in testloader:
+                images, labels = data
+                images, labels = images.to(device), labels.to(device)
+
+                outputs = net(images)
+                _, predicted = torch.max(outputs.data, 1)
+                total += labels.size(0)
+                correct += (predicted == labels).sum().item()
+
+        test_acc = 100 * correct / total
+
+        class_correct = list(0. for i in range(10))
+        class_total = list(0. for i in range(10))
+        with torch.no_grad():
+            for data in testloader:
+                images, labels = data
+                images, labels = images.to(device), labels.to(device)
+
+                outputs = net(images)
+                _, predicted = torch.max(outputs, 1)
+                c = (predicted == labels).squeeze()
+                for i in range(4):
+                    label = labels[i]
+                    class_correct[label] += c[i].item()
+                    class_total[label] += 1
+
+        print("Test Accuracy: %.4f" % test_acc)
+        class_acc = {}
+        for i in range(10):
+            print('Accuracy of %5s : %2d %%' % (
+                classes[i], 100 * class_correct[i] / class_total[i]))
+            class_acc["Accuracy of %5s" %
+                    (classes[i])] = 100 * class_correct[i] / class_total[i]
+
+        wandb.log(class_acc, commit=False)
+        wandb.log({"Examples": example_images,
                "Test Acc": test_acc,
                "Loss": running_loss})
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
An exception running this in sagemaker:
```
Failure reason
AlgorithmError: ExecuteUserScriptError: Command "/usr/bin/python -m cifar10 --batch_size 256 --conv1_channels 128 --conv2_channels 256 --epochs 5 --hidden_nodes 29 --lr 0.00028355188349642445 --momentum 0.9" wandb: Currently logged in as: jeffr (use `wandb login --relogin` to force relogin) wandb: Currently logged in as: jeffr (use `wandb login --relogin` to force relogin) Traceback (most recent call last): File "/opt/ml/code/client/wandb/sdk/wandb_init.py", line 954, in init run = wi.init() File "/opt/ml/code/client/wandb/sdk/wandb_init.py", line 499, in init backend.ensure_launched() File "/opt/ml/code/client/wandb/sdk/backend/backend.py", line 222, in ensure_launched self.wandb_process.start() File "/usr/lib/python3.6/multiprocessing/process.py", line 105, in start self._popen = self._Popen(self) File "/usr/lib/python3.6/multiprocessing/context.py", line 284, in _Popen return Popen(process_obj) File "/usr/lib/python3.6/multiprocessing/popen_spawn_posix.py", line 32, in __ini
```
It passes with this change.