### PR TITLE
Update Pipeline_Versioning_with_W&B_Artifacts_(PyTorch).ipynb

### DIFF
--- a/colabs/wandb-artifacts/Pipeline_Versioning_with_W&B_Artifacts.ipynb
+++ b/colabs/wandb-artifacts/Pipeline_Versioning_with_W&B_Artifacts.ipynb
@@ -81,7 +81,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "# Compatible with wandb version 0.9.2+\n",
@@ -92,7 +96,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -128,7 +136,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "import random \n",
@@ -208,7 +220,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "def load_and_log():\n",
@@ -362,7 +378,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "def preprocess(dataset, normalize=True, expand_dims=True):\n",
@@ -401,7 +421,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "def preprocess_and_log(steps):\n",
@@ -456,7 +480,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "steps = {\"normalize\": True,\n",
@@ -521,7 +549,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "!tree artifacts"
@@ -577,7 +609,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "from math import floor\n",
@@ -638,7 +674,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "def build_model_and_log(config):\n",
@@ -715,7 +755,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "import torch.nn.functional as F\n",
@@ -802,7 +846,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "def evaluate(model, test_loader):\n",
@@ -842,8 +890,9 @@
     "    highest_k_losses = losses[argsort_loss[-k:]]\n",
     "    hardest_k_examples = testing_set[argsort_loss[-k:]][0]\n",
     "    true_labels = testing_set[argsort_loss[-k:]][1]\n",
+    "    predicted_labels = predictions[argsort_loss[-k:]]\n",
     "\n",
-    "    return highest_k_losses, hardest_k_examples, true_labels, predictions"
+    "    return highest_k_losses, hardest_k_examples, true_labels, predicted_labels"
    ]
   },
   {
@@ -859,7 +908,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "from torch.utils.data import DataLoader\n",
@@ -934,7 +987,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "train_config = {\"batch_size\": 128,\n",

--- a/colabs/wandb-artifacts/Pipeline_Versioning_with_W&B_Artifacts.ipynb
+++ b/colabs/wandb-artifacts/Pipeline_Versioning_with_W&B_Artifacts.ipynb
@@ -3,12 +3,10 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8add397a",
    "metadata": {},
    "source": [
     "<a href=\"https://colab.research.google.com/github/wandb/examples/blob/master/colabs/wandb-artifacts/Pipeline_Versioning_with_W&B_Artifacts.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
-    "\n",
-    "<!--- @wandbcode{artifacts-pipeline} -->\n"
+    "<!--- @wandbcode{artifacts-pipeline} -->"
    ]
   },
   {
@@ -81,11 +79,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Compatible with wandb version 0.9.2+\n",
@@ -96,11 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -136,11 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import random \n",
@@ -220,11 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def load_and_log():\n",
@@ -378,11 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def preprocess(dataset, normalize=True, expand_dims=True):\n",
@@ -421,11 +399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def preprocess_and_log(steps):\n",
@@ -480,11 +454,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "steps = {\"normalize\": True,\n",
@@ -549,11 +519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!tree artifacts"
@@ -609,11 +575,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from math import floor\n",
@@ -674,11 +636,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def build_model_and_log(config):\n",
@@ -755,11 +713,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import torch.nn.functional as F\n",
@@ -846,11 +800,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def evaluate(model, test_loader):\n",
@@ -908,11 +858,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from torch.utils.data import DataLoader\n",
@@ -987,11 +933,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "train_config = {\"batch_size\": 128,\n",

--- a/colabs/wandb-artifacts/Pipeline_Versioning_with_W&B_Artifacts_(PyTorch).ipynb
+++ b/colabs/wandb-artifacts/Pipeline_Versioning_with_W&B_Artifacts_(PyTorch).ipynb
@@ -3,13 +3,10 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "e2141321",
    "metadata": {},
    "source": [
     "<a href=\"https://colab.research.google.com/github/wandb/examples/blob/master/colabs/wandb-artifacts/Pipeline_Versioning_with_W&B_Artifacts_(PyTorch).ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
-    "\n",
-    "\n",
-    "<!--- @wandbcode{artifacts-pipeline-pytorch} -->\n"
+    "<!--- @wandbcode{artifacts-pipeline-pytorch} -->"
    ]
   },
   {

--- a/colabs/wandb-artifacts/Pipeline_Versioning_with_W&B_Artifacts_(PyTorch).ipynb
+++ b/colabs/wandb-artifacts/Pipeline_Versioning_with_W&B_Artifacts_(PyTorch).ipynb
@@ -842,8 +842,9 @@
     "    highest_k_losses = losses[argsort_loss[-k:]]\n",
     "    hardest_k_examples = testing_set[argsort_loss[-k:]][0]\n",
     "    true_labels = testing_set[argsort_loss[-k:]][1]\n",
+    "    predicted_labels = predictions[argsort_loss[-k:]]\n",
     "\n",
-    "    return highest_k_losses, hardest_k_examples, true_labels, predictions"
+    "    return highest_k_losses, hardest_k_examples, true_labels, predicted_labels"
    ]
   },
   {


### PR DESCRIPTION
Hi there,

If I'm correct, right now, when computing the k-examples with the highest loss, the example uploads the images to wandb with an incorrect pred label because it's using the `predictions` tensor that is not ordered by which predictions had a bigger loss. The change I propose solves this issue, which happens in [this notebooks](https://github.com/wandb/examples/blob/master/colabs/wandb-artifacts/Pipeline_Versioning_with_W%26B_Artifacts.ipynb) too. 

It's also possible I'm missing something, so if I'm wrong I'd appreciate some feedback.

Have a good weekend!