### PR TITLE
Add import `wandb` to Config Colab

### DIFF
--- a/colabs/wandb-log/Configs_in_W&B.ipynb
+++ b/colabs/wandb-log/Configs_in_W&B.ipynb
@@ -1,367 +1,428 @@
 {
- "accelerator": "GPU",
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "8b85eb26",
-   "metadata": {
-    "colab_type": "text",
-    "id": "view-in-github"
-   },
-   "source": [
-    "<a href=\"https://colab.research.google.com/github/wandb/examples/blob/master/colabs/wandb-log/Configs_in_W&B.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/SauravMaheshkar/examples/blob/master/colabs/wandb-log/Configs_in_W%26B.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "KB1JPe9YN9wb"
+      },
+      "source": [
+        "<img src=\"https://i.imgur.com/gb6B4ig.png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+        "\n",
+        "# Quickstart\n",
+        "Use [Weights & Biases](https://wandb.ai)\n",
+        "for machine learning experiment tracking, dataset versioning, and project collaboration.\n",
+        "\n",
+        "<div><img /></div>\n",
+        "\n",
+        "<img src=\"http://wandb.me/mini-diagram\" width=\"650\" alt=\"Weights & Biases\" />\n",
+        "\n",
+        "<div><img /></div>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "2w11m9aZN9wc"
+      },
+      "source": [
+        "To get started, just `pip install` the package and log using `wandb.login()` \n",
+        "If this is your first time using `wandb`, you'll need to sign up. It's easy!"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Qttl-lmjN9wd"
+      },
+      "outputs": [],
+      "source": [
+        "%%capture\n",
+        "!pip install wandb"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "SK_tj6UNN9wd"
+      },
+      "outputs": [],
+      "source": [
+        "import wandb\n",
+        "wandb.login()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "5HWSb3LzN9wd"
+      },
+      "source": [
+        "# What's a `config` for?\n",
+        "\n",
+        "Set [`wandb.config`](https://docs.wandb.ai/guides/track/config)\n",
+        "once at the beginning of your script to save your training configuration: hyperparameters, input settings like dataset name or model type, and include any other independent variables or metadata for your experiments.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "m5kEvn2XN9we"
+      },
+      "source": [
+        "\n",
+        "### Why does that matter?\n",
+        "\n",
+        "This is useful for analyzing your experiments and reproducing your work in the future. You'll be able to group by `config` values in our web interface, comparing the settings of different runs and seeing how these affect the output.\n",
+        "\n",
+        "> Note that output metrics or dependent variables (like loss and accuracy) should be saved with `wandb.log` instead.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "I8Ndek4QN9we"
+      },
+      "source": [
+        "# How do I set up a `config`?"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "0dbVgC7ON9we"
+      },
+      "source": [
+        "Your `config` should be set just once at the beginning of your training experiment.\n",
+        "\n",
+        "But workflows differ, so we offer a number of ways to set up your config.\n",
+        "\n",
+        "Let's look at all the ways you can create and send the config dictionary to the Dashboard!"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "pCLsSb-2N9we"
+      },
+      "source": [
+        "## Setting the `config` at `init`ialization\n",
+        "\n",
+        "The best time to set the `config` values is when you call [`wandb.init`](https://docs.wandb.ai/guides/track/launch),\n",
+        "by passing a dictionary as the `config` keyword argument."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "UHJMjX5tN9wf"
+      },
+      "outputs": [],
+      "source": [
+        "import wandb\n",
+        "\n",
+        "wandb.init(project=\"config_example\",\n",
+        "           config={\"dataset\": \"CelebA\", \"type\": \"baseline\"});"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qPcPmlTNN9wf"
+      },
+      "source": [
+        "Head to the [Run page](https://docs.wandb.ai/ref/app/pages/run-page)\n",
+        "linked in the output of `wandb.init`\n",
+        "and head to the [Overview tab](https://docs.wandb.ai/ref/app/pages/run-page#overview-tab)\n",
+        "(top of the list of panels on the left-most side of the screen).\n",
+        "You'll see a \"Config\" section that looks like this:\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "cJdgx0bQN9wf"
+      },
+      "source": [
+        "<img src=\"https://i.imgur.com/nAC9KEF.png\" width=\"450\"/>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "UyKdg03IN9wg"
+      },
+      "source": [
+        "You give us a (possibly nested) dictionary as your `config`, and we'll flatten the names using dots in our backend.\n",
+        "\n",
+        "> _Side Note_: We recommend that you avoid using dots in your config variable names, and use a dash or underscore instead. Once you've created your `config` dictionary, if your script accesses `wandb.config` keys below the root, use the dictionary access syntax, `[\"key\"][\"foo\"]`, instead of the attribute access syntax, `config.key.foo`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "QsvEbTDIN9wg"
+      },
+      "source": [
+        "\n",
+        " ## Adding to the `config` by hand\n",
+        "You can add more parameters to the `config` later if you want:\n",
+        "\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "wXcS4eaUN9wg"
+      },
+      "outputs": [],
+      "source": [
+        "wandb.config.epochs = 4\n",
+        "wandb.config[\"batch_size\"] = 32"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "O8YYAA1sN9wg"
+      },
+      "source": [
+        "Now, your Config section on the dashboard has been updated:\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "7SQN4IJuN9wg"
+      },
+      "source": [
+        "<img src=\"https://i.imgur.com/cnvEuSR.png\" width=\"450\"/>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "NArdo8gUN9wg"
+      },
+      "source": [
+        "## Adding to the `config` with `argparse`\n",
+        "\n",
+        "`config` is a dictionary-like object, and it can be built from lots of dictionary-like objects.\n",
+        "\n",
+        "For example, you can pass in the arguments object produced by `argparse`.\n",
+        "[`argparse`](https://docs.python.org/3/library/argparse.html), short for `arg`ument `parse`r, is a standard library module in Python 3.2 and above that makes it easy to write scripts that take advantage of all the flexibility and power of command line arguments. And it's Pythonic!\n",
+        "\n",
+        "This is especially convenient for tracking results from scripts that are launched from the command line."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "4a8vNjm8N9wh"
+      },
+      "outputs": [],
+      "source": [
+        "import argparse\n",
+        "\n",
+        "parser = argparse.ArgumentParser()\n",
+        "parser.add_argument('-b', '--batch_per_gpu', type=int, default=8,\n",
+        "                    help='input batch size for training (default: 8)')\n",
+        "parser.add_argument('-wd', '--weight_decay', type=float, default=0.1,\n",
+        "                    help='weight decay (default: 0.1)')\n",
+        "\n",
+        "args = parser.parse_args(args=[])\n",
+        "wandb.config.update(args)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "JuKKYUeyN9wh"
+      },
+      "source": [
+        "Here's the updated Config panel:\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "OSiXeb-2N9wh"
+      },
+      "source": [
+        "\n",
+        "<img src=\"https://i.imgur.com/zWSpGNy.png\" width=450>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "31sioi00N9wh"
+      },
+      "source": [
+        "## Updating the `config` with the API\n",
+        "\n",
+        "What if your run has finished, but you realized you forgot to log something?\n",
+        "\n",
+        "Never fear, you can always use the\n",
+        "[public API](https://docs.wandb.ai/ref/python/public-api)\n",
+        "to update your `config`\n",
+        "(or anything else about your run!)\n",
+        "at any time. You just need to know the details of the `run` you want to update.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "iiBKCcL5N9wh"
+      },
+      "outputs": [],
+      "source": [
+        "api = wandb.Api()\n",
+        "\n",
+        "# pulling the relevant info automatically from the run object\n",
+        "# this can also be found on the website\n",
+        "username = wandb.run.entity\n",
+        "project = wandb.run.project\n",
+        "run_id = wandb.run.id\n",
+        "\n",
+        "run = api.run(f\"{username}/{project}/{run_id}\")\n",
+        "run.config[\"bar\"] = 32\n",
+        "run.update()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "FyFRgVkWN9wh"
+      },
+      "source": [
+        "Here's what the final Config panel looks like:\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BYOwh6FaN9wh"
+      },
+      "source": [
+        "<img src=\"https://i.imgur.com/mxmIbyK.png\" width=450>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "RVl3wjUAN9wh"
+      },
+      "source": [
+        "# Using `config` for great good!\n",
+        "The `config` parameters are useful for performing grouping, filtering, and aggregating on your experiments and their results.\n",
+        "\n",
+        "### The examples below come from the project [here](https://wandb.ai/wandb/DistHyperOpt).\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qiNxzWNvN9wi"
+      },
+      "source": [
+        "## Filtering Runs\n",
+        "Filter tab allows you to display the runs that quality one or more conditions. These conditions can be formed by applying relational operators to any of the parameters logged in the `config` file.\n",
+        "\n",
+        "[Our example project](https://wandb.ai/wandb/DistHyperOpt) compares various hyper-parameter tuning methods and has more than 80 runs. Each run has a \"Job Type\" logged in the `config` which corresponds\n",
+        "\n",
+        "Let's say you want to visualize only the ones that are generated by a particular tuning algorithm, like Population Based Traing (`pbt`). You can do that by applying a filter on \"Job Type\".\n",
+        "\n",
+        "Run the cell below to see this in action!"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "t7A-4OhDN9wi"
+      },
+      "outputs": [],
+      "source": [
+        "from IPython import display\n",
+        "\n",
+        "display.YouTubeVideo(\"aSMXwOSPtJE\", rel=0, width=450)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "VQUiMzBaN9wi"
+      },
+      "source": [
+        "## Grouping Runs\n",
+        "You can group your experiments in the dashboard of your project based on a particular column from `config`. A common use case for this would be grouping sub-experiments within a larger project.\n",
+        "\n",
+        "Our runs are grouped based on \"Job Type\". The Group tab is located next to the Filter Tab. You can group your runs by any parameter present in the config.\n",
+        "\n",
+        "![Imgur](https://i.imgur.com/gTLKRP7.png?1)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "KaWIDoimN9wi"
+      },
+      "source": [
+        "## Parallel Coordinates Chart\n",
+        "\n",
+        "Often, the main thing we want to do with a group of Runs is make comparisons.\n",
+        "\n",
+        "The W&B Dashboard includes a Chart type for exactly this purpose:\n",
+        "the Parallel Coordinates chart.\n",
+        "\n",
+        "A Parallel Coordinates chart represents each Run in the group as a line.\n",
+        "This line passes through as many of the `config` values\n",
+        "or logged metrics as you like,\n",
+        "and is colored by its value on a single metric.\n",
+        "This lets you take in, at a glance,\n",
+        "which hyperparameter configurations were most and least successful.\n",
+        "See the example below.\n",
+        "\n",
+        "Head to a [group of Runs in this project](https://wandb.ai/wandb/DistHyperOpt/groups/dcgan_train)\n",
+        "and build a Parallel Coordinates chart like the one pictured below\n",
+        "by \n",
+        "1. clicking the + sign in the top-right corner, aligned with \"Charts\",\n",
+        "2. selecting \"Parallel Coordinates\" from the available Charts, and\n",
+        "3. adding the columns in the image, in order.\n",
+        "\n",
+        "![Imgur](https://i.imgur.com/ugrpq9K.png)"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "toc_visible": true,
+      "name": "Configs_in_W&B.ipynb",
+      "provenance": [],
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<img src=\"https://i.imgur.com/gb6B4ig.png\" width=\"400\" alt=\"Weights & Biases\" />\n",
-    "\n",
-    "# Quickstart\n",
-    "Use [Weights & Biases](https://wandb.ai)\n",
-    "for machine learning experiment tracking, dataset versioning, and project collaboration.\n",
-    "\n",
-    "<div><img /></div>\n",
-    "\n",
-    "<img src=\"http://wandb.me/mini-diagram\" width=\"650\" alt=\"Weights & Biases\" />\n",
-    "\n",
-    "<div><img /></div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To get started, just `pip install` the package and log using `wandb.login()` \n",
-    "If this is your first time using `wandb`, you'll need to sign up. It's easy!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%capture\n",
-    "!pip install wandb"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wandb.login()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# What's a `config` for?\n",
-    "\n",
-    "Set [`wandb.config`](https://docs.wandb.ai/guides/track/config)\n",
-    "once at the beginning of your script to save your training configuration: hyperparameters, input settings like dataset name or model type, and include any other independent variables or metadata for your experiments.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "### Why does that matter?\n",
-    "\n",
-    "This is useful for analyzing your experiments and reproducing your work in the future. You'll be able to group by `config` values in our web interface, comparing the settings of different runs and seeing how these affect the output.\n",
-    "\n",
-    "> Note that output metrics or dependent variables (like loss and accuracy) should be saved with `wandb.log` instead.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# How do I set up a `config`?"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Your `config` should be set just once at the beginning of your training experiment.\n",
-    "\n",
-    "But workflows differ, so we offer a number of ways to set up your config.\n",
-    "\n",
-    "Let's look at all the ways you can create and send the config dictionary to the Dashboard!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Setting the `config` at `init`ialization\n",
-    "\n",
-    "The best time to set the `config` values is when you call [`wandb.init`](https://docs.wandb.ai/guides/track/launch),\n",
-    "by passing a dictionary as the `config` keyword argument."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import wandb\n",
-    "\n",
-    "wandb.init(project=\"config_example\",\n",
-    "           config={\"dataset\": \"CelebA\", \"type\": \"baseline\"});"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Head to the [Run page](https://docs.wandb.ai/ref/app/pages/run-page)\n",
-    "linked in the output of `wandb.init`\n",
-    "and head to the [Overview tab](https://docs.wandb.ai/ref/app/pages/run-page#overview-tab)\n",
-    "(top of the list of panels on the left-most side of the screen).\n",
-    "You'll see a \"Config\" section that looks like this:\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<img src=\"https://i.imgur.com/nAC9KEF.png\" width=\"450\"/>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You give us a (possibly nested) dictionary as your `config`, and we'll flatten the names using dots in our backend.\n",
-    "\n",
-    "> _Side Note_: We recommend that you avoid using dots in your config variable names, and use a dash or underscore instead. Once you've created your `config` dictionary, if your script accesses `wandb.config` keys below the root, use the dictionary access syntax, `[\"key\"][\"foo\"]`, instead of the attribute access syntax, `config.key.foo`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    " ## Adding to the `config` by hand\n",
-    "You can add more parameters to the `config` later if you want:\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wandb.config.epochs = 4\n",
-    "wandb.config[\"batch_size\"] = 32"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now, your Config section on the dashboard has been updated:\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<img src=\"https://i.imgur.com/cnvEuSR.png\" width=\"450\"/>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Adding to the `config` with `argparse`\n",
-    "\n",
-    "`config` is a dictionary-like object, and it can be built from lots of dictionary-like objects.\n",
-    "\n",
-    "For example, you can pass in the arguments object produced by `argparse`.\n",
-    "[`argparse`](https://docs.python.org/3/library/argparse.html), short for `arg`ument `parse`r, is a standard library module in Python 3.2 and above that makes it easy to write scripts that take advantage of all the flexibility and power of command line arguments. And it's Pythonic!\n",
-    "\n",
-    "This is especially convenient for tracking results from scripts that are launched from the command line."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import argparse\n",
-    "\n",
-    "parser = argparse.ArgumentParser()\n",
-    "parser.add_argument('-b', '--batch_per_gpu', type=int, default=8,\n",
-    "                    help='input batch size for training (default: 8)')\n",
-    "parser.add_argument('-wd', '--weight_decay', type=float, default=0.1,\n",
-    "                    help='weight decay (default: 0.1)')\n",
-    "\n",
-    "args = parser.parse_args(args=[])\n",
-    "wandb.config.update(args)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Here's the updated Config panel:\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "<img src=\"https://i.imgur.com/zWSpGNy.png\" width=450>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Updating the `config` with the API\n",
-    "\n",
-    "What if your run has finished, but you realized you forgot to log something?\n",
-    "\n",
-    "Never fear, you can always use the\n",
-    "[public API](https://docs.wandb.ai/ref/python/public-api)\n",
-    "to update your `config`\n",
-    "(or anything else about your run!)\n",
-    "at any time. You just need to know the details of the `run` you want to update.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "api = wandb.Api()\n",
-    "\n",
-    "# pulling the relevant info automatically from the run object\n",
-    "# this can also be found on the website\n",
-    "username = wandb.run.entity\n",
-    "project = wandb.run.project\n",
-    "run_id = wandb.run.id\n",
-    "\n",
-    "run = api.run(f\"{username}/{project}/{run_id}\")\n",
-    "run.config[\"bar\"] = 32\n",
-    "run.update()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Here's what the final Config panel looks like:\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<img src=\"https://i.imgur.com/mxmIbyK.png\" width=450>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Using `config` for great good!\n",
-    "The `config` parameters are useful for performing grouping, filtering, and aggregating on your experiments and their results.\n",
-    "\n",
-    "### The examples below come from the project [here](https://wandb.ai/wandb/DistHyperOpt).\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Filtering Runs\n",
-    "Filter tab allows you to display the runs that quality one or more conditions. These conditions can be formed by applying relational operators to any of the parameters logged in the `config` file.\n",
-    "\n",
-    "[Our example project](https://wandb.ai/wandb/DistHyperOpt) compares various hyper-parameter tuning methods and has more than 80 runs. Each run has a \"Job Type\" logged in the `config` which corresponds\n",
-    "\n",
-    "Let's say you want to visualize only the ones that are generated by a particular tuning algorithm, like Population Based Traing (`pbt`). You can do that by applying a filter on \"Job Type\".\n",
-    "\n",
-    "Run the cell below to see this in action!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from IPython import display\n",
-    "\n",
-    "display.YouTubeVideo(\"aSMXwOSPtJE\", rel=0, width=450)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Grouping Runs\n",
-    "You can group your experiments in the dashboard of your project based on a particular column from `config`. A common use case for this would be grouping sub-experiments within a larger project.\n",
-    "\n",
-    "Our runs are grouped based on \"Job Type\". The Group tab is located next to the Filter Tab. You can group your runs by any parameter present in the config.\n",
-    "\n",
-    "![Imgur](https://i.imgur.com/gTLKRP7.png?1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Parallel Coordinates Chart\n",
-    "\n",
-    "Often, the main thing we want to do with a group of Runs is make comparisons.\n",
-    "\n",
-    "The W&B Dashboard includes a Chart type for exactly this purpose:\n",
-    "the Parallel Coordinates chart.\n",
-    "\n",
-    "A Parallel Coordinates chart represents each Run in the group as a line.\n",
-    "This line passes through as many of the `config` values\n",
-    "or logged metrics as you like,\n",
-    "and is colored by its value on a single metric.\n",
-    "This lets you take in, at a glance,\n",
-    "which hyperparameter configurations were most and least successful.\n",
-    "See the example below.\n",
-    "\n",
-    "Head to a [group of Runs in this project](https://wandb.ai/wandb/DistHyperOpt/groups/dcgan_train)\n",
-    "and build a Parallel Coordinates chart like the one pictured below\n",
-    "by \n",
-    "1. clicking the + sign in the top-right corner, aligned with \"Charts\",\n",
-    "2. selecting \"Parallel Coordinates\" from the available Charts, and\n",
-    "3. adding the columns in the image, in order.\n",
-    "\n",
-    "![Imgur](https://i.imgur.com/ugrpq9K.png)"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "include_colab_link": true,
-   "toc_visible": true
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "name": "python3"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 0
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
This PR adds the missing `import wandb` to the Config Colab Notebook.