### PR TITLE
fixes profiling colab crash

### DIFF
--- a/colabs/pytorch-lightning/Profile_PyTorch_Code.ipynb
+++ b/colabs/pytorch-lightning/Profile_PyTorch_Code.ipynb
@@ -1,486 +1,437 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "h8sLHlDHRXXz"
-      },
-      "source": [
-        "<img src=\"https://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
-        "\n",
-        "<!--- @wandbcode{trace-colab} -->\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "7YtSr2DLRXX5"
-      },
-      "source": [
-        "# Profiling PyTorch Code"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ULFmaZBZRXX6"
-      },
-      "source": [
-        "This notebook demonstrates how to incorporate [PyTorch Kineto](https://github.com/pytorch/kineto)'s\n",
-        "[Tensorboard plugin](https://github.com/pytorch/kineto/blob/master/tb_plugin/README.md)\n",
-        "for profiling PyTorch code\n",
-        "with [PyTorch Lightning](https://pytorch-lightning.readthedocs.io/)\n",
-        "as the high-level training API\n",
-        "and\n",
-        "[Weights & Biases](https://wandb.ai/site)\n",
-        "as the logging solution.\n",
-        "\n",
-        "The final result looks something like what you see below:"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "M7rCJNjtRXX7"
-      },
-      "source": [
-        "![](https://i.imgur.com/fwSc5Z9.png)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "6MJoxj-0RXX7"
-      },
-      "source": [
-        "The work done by processes, threads, and streams on the CPU and GPU\n",
-        "is displayed along with precise timing information\n",
-        "in an interactive viewer that can be incorporated into\n",
-        "Weights & Biases\n",
-        "[workspaces](https://docs.wandb.ai/ref/app/pages/workspaces)\n",
-        "and [Reports](https://docs.wandb.ai/guides/reports)\n",
-        "or exported to external viewers."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "-SW90DCrRXX8"
-      },
-      "source": [
-        "That means you can incorporate tracing and profiling into\n",
-        "your model training and evaluation pipeline --\n",
-        "storing, visualizing, and communicating\n",
-        "performance results alongside other key metrics and metadata,\n",
-        "like [loss curves](https://docs.wandb.ai/guides/track/log),\n",
-        "[hard examples from datasets](https://docs.wandb.ai/guides/data-vis),\n",
-        "and [hyperparameter optimization results](https://docs.wandb.ai/guides/sweeps)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "t55PmFVJRXX8"
-      },
-      "source": [
-        "> _NB:_ This tool is based on the\n",
-        "[Chrome Trace Viewer](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool),\n",
-        "which works best with that browser."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ZC0EdJBpRXX9"
-      },
-      "outputs": [],
-      "source": [
-        "%%capture\n",
-        "!pip install wandb pytorch_lightning torch_tb_profiler"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "OgO1Yh1-RXX_"
-      },
-      "outputs": [],
-      "source": [
-        "import glob\n",
-        "\n",
-        "import pytorch_lightning as pl\n",
-        "import torch\n",
-        "import torch.nn as nn\n",
-        "import torch.nn.functional as F\n",
-        "import torch.optim as optim\n",
-        "import torchvision\n",
-        "from torchvision import datasets, transforms\n",
-        "\n",
-        "from torch.profiler import tensorboard_trace_handler\n",
-        "import wandb\n",
-        "\n",
-        "# drop slow mirror from list of MNIST mirrors\n",
-        "torchvision.datasets.MNIST.mirrors = [mirror for mirror in torchvision.datasets.MNIST.mirrors\n",
-        "                                      if not mirror.startswith(\"http://yann.lecun.com\")]\n",
-        "                                      \n",
-        "# login to W&B\n",
-        "wandb.login()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "QAt34DIIRXYA"
-      },
-      "source": [
-        "# Set Up Profiled Training"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "MbakotteRXYA"
-      },
-      "source": [
-        "## Network Module"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "JBqe-SUNRXYB"
-      },
-      "source": [
-        "To profile neural network code,\n",
-        "we first need to write it.\n",
-        "\n",
-        "For this demo,\n",
-        "we'll stick with a simple\n",
-        "[LeNet](http://yann.lecun.com/exdb/lenet/)-style DNN,\n",
-        "based on the\n",
-        "[PyTorch introductory tutorial](https://pytorch.org/tutorials/recipes/recipes/defining_a_neural_network.html)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "11cy0sWORXYB"
-      },
-      "outputs": [],
-      "source": [
-        "OPTIMIZERS = {\n",
-        "    \"Adadelta\": optim.Adadelta,\n",
-        "    \"Adagrad\" : optim.Adagrad,\n",
-        "    \"SGD\": optim.SGD,\n",
-        "}\n",
-        "\n",
-        "class Net(pl.LightningModule):\n",
-        "  \"\"\"Very simple LeNet-style DNN, plus DropOut.\"\"\"\n",
-        "\n",
-        "  def __init__(self, optimizer=\"Adadelta\"):\n",
-        "    super(Net, self).__init__()\n",
-        "    self.conv1 = nn.Conv2d(1, 32, 3, 1)\n",
-        "    self.conv2 = nn.Conv2d(32, 64, 3, 1)\n",
-        "    self.dropout1 = nn.Dropout(0.25)\n",
-        "    self.dropout2 = nn.Dropout(0.5)\n",
-        "    self.fc1 = nn.Linear(9216, 128)\n",
-        "    self.fc2 = nn.Linear(128, 10)\n",
-        "\n",
-        "    self.optimizer = self.set_optimizer(optimizer)\n",
-        "\n",
-        "  def forward(self, x):\n",
-        "    x = self.conv1(x)\n",
-        "    x = F.relu(x)\n",
-        "    x = self.conv2(x)\n",
-        "    x = F.relu(x)\n",
-        "    x = F.max_pool2d(x, 2)\n",
-        "    x = self.dropout1(x)\n",
-        "    x = torch.flatten(x, 1)\n",
-        "    x = self.fc1(x)\n",
-        "    x = F.relu(x)\n",
-        "    x = self.dropout2(x)\n",
-        "    x = self.fc2(x)\n",
-        "    output = F.log_softmax(x, dim=1)\n",
-        "    return output\n",
-        "\n",
-        "  def set_optimizer(self, optimizer):\n",
-        "    return OPTIMIZERS[optimizer]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "QLDjJYvjRXYC"
-      },
-      "source": [
-        "To get this module to work with PyTorch Lightning,\n",
-        "we need to define two more methods,\n",
-        "which hook into the training loop.\n",
-        "\n",
-        "Check out [this tutorial video and notebook](http://wandb.me/lit-video)\n",
-        "for more on using PyTorch Lightning and W&B."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "xS1ZLJdCRXYC"
-      },
-      "outputs": [],
-      "source": [
-        "def training_step(self, batch, idx):\n",
-        "  inputs, labels = batch\n",
-        "  outputs = self(inputs)\n",
-        "  loss =  F.nll_loss(outputs, labels)\n",
-        "\n",
-        "  return {\"loss\": loss}\n",
-        "    \n",
-        "def configure_optimizers(self):\n",
-        "  return self.optimizer(self.parameters(), lr=0.1)\n",
-        "\n",
-        "Net.training_step = training_step\n",
-        "Net.configure_optimizers = configure_optimizers"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5LX9yFEeRXYD"
-      },
-      "source": [
-        "## Profiler Callback"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "wxXMljOMRXYD"
-      },
-      "source": [
-        "The profiler operates a bit like a PyTorch optimizer:\n",
-        "it has a `.step` method that we need to call\n",
-        "to demarcate the code we're interested in profiling.\n",
-        "\n",
-        "A single training step (forward and backward prop)\n",
-        "is both the typical target of performance optimizations\n",
-        "and already rich enough to more than fill out a profiling trace,\n",
-        "so we want to call `.step` on each step.\n",
-        "\n",
-        "The cell below defines a quick-and-dirty\n",
-        "method for doing so in PyTorch Lightning using the\n",
-        "[`Callback` system](https://pytorch-lightning.readthedocs.io/en/stable/extensions/callbacks.html)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "tVoEwPJ0RXYE"
-      },
-      "outputs": [],
-      "source": [
-        "class TorchTensorboardProfilerCallback(pl.Callback):\n",
-        "  \"\"\"Quick-and-dirty Callback for invoking TensorboardProfiler during training.\n",
-        "  \n",
-        "  For greater robustness, extend the pl.profiler.profilers.BaseProfiler. See\n",
-        "  https://pytorch-lightning.readthedocs.io/en/stable/advanced/profiler.html\"\"\"\n",
-        "\n",
-        "  def __init__(self, profiler):\n",
-        "    super().__init__()\n",
-        "    self.profiler = profiler \n",
-        "\n",
-        "  def on_train_batch_end(self, trainer, pl_module, outputs, *args, **kwargs):\n",
-        "    self.profiler.step()\n",
-        "    pl_module.log_dict(outputs)  # also logging the loss, while we're here"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "H-3ONoF0RXYE"
-      },
-      "source": [
-        "# Run Profiled Training"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "WLgdOE2WRXYE"
-      },
-      "source": [
-        "We're now ready to go!\n",
-        "\n",
-        "The cell below creates a `DataLoader`\n",
-        "based on the information in the `config`uration dictionary.\n",
-        "Choices made here have a substantial impact on performance\n",
-        "and show up very markedly in the trace.\n",
-        "\n",
-        "After you've run with the default values,\n",
-        "check out the creation of the `trainloader`\n",
-        "and the `trainer`\n",
-        "for comments on what these arguments do\n",
-        "and then try a few different choices out, as suggested below."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ZhtHzOgsRXYE"
-      },
-      "outputs": [],
-      "source": [
-        "# initial values are defaults, for all except batch_size, which has no default\n",
-        "config = {\"batch_size\": 32,  # try log-spaced values from 1 to 50,000\n",
-        "          \"num_workers\": 0,  # try 0, 1, and 2\n",
-        "          \"pin_memory\": False,  # try False and True\n",
-        "          \"precision\": 32,  # try 16 and 32\n",
-        "          \"optimizer\": \"Adadelta\",  # try optim.Adadelta and optim.SGD\n",
-        "          }\n",
-        "\n",
-        "with wandb.init(project=\"trace\", config=config) as run:\n",
-        "\n",
-        "    # Set up MNIST data\n",
-        "    transform=transforms.Compose([\n",
-        "        transforms.ToTensor(),\n",
-        "        transforms.Normalize((0.1307,), (0.3081,))\n",
-        "        ])\n",
-        "\n",
-        "    dataset = datasets.MNIST(\"../data\", train=True, download=True,\n",
-        "                            transform=transform)\n",
-        "\n",
-        "    ## Using a raw DataLoader, rather than LightningDataModule, for greater transparency\n",
-        "    trainloader = torch.utils.data.DataLoader(\n",
-        "      dataset,\n",
-        "      # Key performance-relevant configuration parameters:\n",
-        "      ## batch_size: how many datapoints are passed through the network at once?\n",
-        "      batch_size=wandb.config.batch_size,\n",
-        "      # larger batch sizes are more compute efficient, up to memory constraints\n",
-        "\n",
-        "      ##  num_workers: how many side processes to launch for dataloading (should be >0)\n",
-        "      num_workers=wandb.config.num_workers,\n",
-        "      # needs to be tuned given model/batch size/compute\n",
-        "\n",
-        "      ## pin_memory: should a fixed \"pinned\" memory block be allocated on the CPU?\n",
-        "      pin_memory=wandb.config.pin_memory,\n",
-        "      # should nearly always be True for GPU models, see https://developer.nvidia.com/blog/how-optimize-data-transfers-cuda-cc/\n",
-        "      )\n",
-        "    \n",
-        "    # Set up model\n",
-        "    model = Net(optimizer=wandb.config[\"optimizer\"])\n",
-        "\n",
-        "    # Set up profiler\n",
-        "    wait, warmup, active, repeat = 1, 1, 2, 1\n",
-        "    total_steps = (wait + warmup + active) * (1 + repeat)\n",
-        "    schedule =  torch.profiler.schedule(\n",
-        "      wait=wait, warmup=warmup, active=active, repeat=repeat)\n",
-        "    profiler = torch.profiler.profile(\n",
-        "      schedule=schedule, on_trace_ready=tensorboard_trace_handler(\"wandb/latest-run/tbprofile\"), with_stack=False)\n",
-        "\n",
-        "    with profiler:\n",
-        "        profiler_callback = TorchTensorboardProfilerCallback(profiler)\n",
-        "\n",
-        "        trainer = pl.Trainer(gpus=1, max_epochs=1, max_steps=total_steps,\n",
-        "                            logger=pl.loggers.WandbLogger(log_model=True, save_code=True),\n",
-        "                            callbacks=[profiler_callback], precision=wandb.config.precision)\n",
-        "\n",
-        "        trainer.fit(model, trainloader)\n",
-        "\n",
-        "    profile_art = wandb.Artifact(f\"trace-{wandb.run.id}\", type=\"profile\")\n",
-        "    profile_art.add_file(glob.glob(\"wandb/latest-run/tbprofile/*.pt.trace.json\")[0], \"trace.pt.trace.json\")\n",
-        "    run.log_artifact(profile_art)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "U-rRWZ8IRXYF"
-      },
-      "source": [
-        "# Reading Profiling Results"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "WL5dvLdsRXYF"
-      },
-      "source": [
-        "Head to the Artifacts tab\n",
-        "(identified by the\n",
-        "[\"stacked pucks\"](https://stackoverflow.com/questions/2822650/why-is-a-database-always-represented-with-a-cylinder)\n",
-        "database icon)\n",
-        "for your W&B [run page](https://docs.wandb.ai/ref/app/pages/run-page),\n",
-        "at the URL that appears in the output of the cell above,\n",
-        "then select the artifact named `trace-`.\n",
-        "In the Files tab, select `trace.pt.trace.json`\n",
-        "to pull up the Trace Viewer.\n",
-        "\n",
-        "> You can also check out an example from an earlier run\n",
-        "[here](https://wandb.ai/wandb/trace/artifacts/profile/trace-224bfvza/56c5d50902233baa7710/files/trace.pt.trace.json)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Rgv1l4vcRXYG"
-      },
-      "source": [
-        "The trace shows which operations were running and when\n",
-        "in each process/thread/stream\n",
-        "on the CPU and on the GPU.\n",
-        "\n",
-        "In the main thread (the one in which the Profiler Steps appear),\n",
-        "locate the following steps:\n",
-        "1. the loading of data (hint: look for `enumerate` on the CPU, nothing on the GPU)\n",
-        "2. the forward pass to calculate the loss (hint: look for simultaneous activity on CPU+GPU,\n",
-        "with [`aten`](https://pytorch.org/cppdocs/#aten) in the operation names)\n",
-        "3. the backward pass to calculate the gradient of the loss (hint: look for simultaneous activity on CPU+GPU, with [`backward`](https://pytorch.org/cppdocs/#autograd) in the operation names).\n",
-        "\n",
-        "If you ran with the default settings\n",
-        "(in particular, `num_workers=0`),\n",
-        "you'll notice that these steps are all run sequentially,\n",
-        "meaning that between loading one batch\n",
-        "and loading the next,\n",
-        "the `DataLoader` is effectively idling,\n",
-        "and during the loading of a batch, the GPU is idling.\n",
-        "\n",
-        "Change `num_workers` in the config to `1` or `2`\n",
-        "and then re-execute the cell above.\n",
-        "You should notice a difference,\n",
-        "in particular in the fraction of time the GPU is active.\n",
-        "(Note: the `DataLoader` may even be hard to find in this case!)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "37rtD08FRXYG"
-      },
-      "source": [
-        "For more on how to read these results, check out\n",
-        "[this W&B Report](http://wandb.me/trace-report)."
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "toc_visible": true,
-      "name": "Profile_PyTorch_Code.ipynb",
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "accelerator": "GPU",
-    "gpuClass": "standard"
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/wandb/examples/blob/master/colabs/pytorch-lightning/Profile_PyTorch_Code.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<!--- @wandbcode{trace-colab} -->"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<img src=\"https://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+    "\n",
+    "<!--- @wandbcode{trace-colab} -->\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Profiling PyTorch Code"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates how to incorporate [PyTorch Kineto](https://github.com/pytorch/kineto)'s\n",
+    "[Tensorboard plugin](https://github.com/pytorch/kineto/blob/master/tb_plugin/README.md)\n",
+    "for profiling PyTorch code\n",
+    "with [PyTorch Lightning](https://pytorch-lightning.readthedocs.io/)\n",
+    "as the high-level training API\n",
+    "and\n",
+    "[Weights & Biases](https://wandb.ai/site)\n",
+    "as the logging solution.\n",
+    "\n",
+    "The final result looks something like what you see below:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/fwSc5Z9.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The work done by processes, threads, and streams on the CPU and GPU\n",
+    "is displayed along with precise timing information\n",
+    "in an interactive viewer that can be incorporated into\n",
+    "Weights & Biases\n",
+    "[workspaces](https://docs.wandb.ai/ref/app/pages/workspaces)\n",
+    "and [Reports](https://docs.wandb.ai/guides/reports)\n",
+    "or exported to external viewers."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That means you can incorporate tracing and profiling into\n",
+    "your model training and evaluation pipeline --\n",
+    "storing, visualizing, and communicating\n",
+    "performance results alongside other key metrics and metadata,\n",
+    "like [loss curves](https://docs.wandb.ai/guides/track/log),\n",
+    "[hard examples from datasets](https://docs.wandb.ai/guides/data-vis),\n",
+    "and [hyperparameter optimization results](https://docs.wandb.ai/guides/sweeps)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> _NB:_ This tool is based on the\n",
+    "[Chrome Trace Viewer](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool),\n",
+    "which works best with that browser."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "!pip install wandb pytorch_lightning torch_tb_profiler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import glob\n",
+    "\n",
+    "import pytorch_lightning as pl\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.functional as F\n",
+    "import torch.optim as optim\n",
+    "import torchvision\n",
+    "from torchvision import datasets, transforms\n",
+    "\n",
+    "from torch.profiler import tensorboard_trace_handler\n",
+    "import wandb\n",
+    "\n",
+    "# drop slow mirror from list of MNIST mirrors\n",
+    "torchvision.datasets.MNIST.mirrors = [mirror for mirror in torchvision.datasets.MNIST.mirrors\n",
+    "                                      if not mirror.startswith(\"http://yann.lecun.com\")]\n",
+    "                                      \n",
+    "# login to W&B\n",
+    "wandb.login()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Set Up Profiled Training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Network Module"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To profile neural network code,\n",
+    "we first need to write it.\n",
+    "\n",
+    "For this demo,\n",
+    "we'll stick with a simple\n",
+    "[LeNet](http://yann.lecun.com/exdb/lenet/)-style DNN,\n",
+    "based on the\n",
+    "[PyTorch introductory tutorial](https://pytorch.org/tutorials/recipes/recipes/defining_a_neural_network.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "OPTIMIZERS = {\n",
+    "    \"Adadelta\": optim.Adadelta,\n",
+    "    \"Adagrad\" : optim.Adagrad,\n",
+    "    \"SGD\": optim.SGD,\n",
+    "}\n",
+    "\n",
+    "class Net(pl.LightningModule):\n",
+    "  \"\"\"Very simple LeNet-style DNN, plus DropOut.\"\"\"\n",
+    "\n",
+    "  def __init__(self, optimizer=\"Adadelta\"):\n",
+    "    super(Net, self).__init__()\n",
+    "    self.conv1 = nn.Conv2d(1, 32, 3, 1)\n",
+    "    self.conv2 = nn.Conv2d(32, 64, 3, 1)\n",
+    "    self.dropout1 = nn.Dropout(0.25)\n",
+    "    self.dropout2 = nn.Dropout(0.5)\n",
+    "    self.fc1 = nn.Linear(9216, 128)\n",
+    "    self.fc2 = nn.Linear(128, 10)\n",
+    "\n",
+    "    self.optimizer = self.set_optimizer(optimizer)\n",
+    "\n",
+    "  def forward(self, x):\n",
+    "    x = self.conv1(x)\n",
+    "    x = F.relu(x)\n",
+    "    x = self.conv2(x)\n",
+    "    x = F.relu(x)\n",
+    "    x = F.max_pool2d(x, 2)\n",
+    "    x = self.dropout1(x)\n",
+    "    x = torch.flatten(x, 1)\n",
+    "    x = self.fc1(x)\n",
+    "    x = F.relu(x)\n",
+    "    x = self.dropout2(x)\n",
+    "    x = self.fc2(x)\n",
+    "    output = F.log_softmax(x, dim=1)\n",
+    "    return output\n",
+    "\n",
+    "  def set_optimizer(self, optimizer):\n",
+    "    return OPTIMIZERS[optimizer]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To get this module to work with PyTorch Lightning,\n",
+    "we need to define two more methods,\n",
+    "which hook into the training loop.\n",
+    "\n",
+    "Check out [this tutorial video and notebook](http://wandb.me/lit-video)\n",
+    "for more on using PyTorch Lightning and W&B."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def training_step(self, batch, idx):\n",
+    "  inputs, labels = batch\n",
+    "  outputs = self(inputs)\n",
+    "  loss =  F.nll_loss(outputs, labels)\n",
+    "\n",
+    "  return {\"loss\": loss}\n",
+    "    \n",
+    "def configure_optimizers(self):\n",
+    "  return self.optimizer(self.parameters(), lr=0.1)\n",
+    "\n",
+    "Net.training_step = training_step\n",
+    "Net.configure_optimizers = configure_optimizers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Profiler Callback"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The profiler operates a bit like a PyTorch optimizer:\n",
+    "it has a `.step` method that we need to call\n",
+    "to demarcate the code we're interested in profiling.\n",
+    "\n",
+    "A single training step (forward and backward prop)\n",
+    "is both the typical target of performance optimizations\n",
+    "and already rich enough to more than fill out a profiling trace,\n",
+    "so we want to call `.step` on each step.\n",
+    "\n",
+    "The cell below defines a quick-and-dirty\n",
+    "method for doing so in PyTorch Lightning using the\n",
+    "[`Callback` system](https://pytorch-lightning.readthedocs.io/en/stable/extensions/callbacks.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class TorchTensorboardProfilerCallback(pl.Callback):\n",
+    "  \"\"\"Quick-and-dirty Callback for invoking TensorboardProfiler during training.\n",
+    "  \n",
+    "  For greater robustness, extend the pl.profiler.profilers.BaseProfiler. See\n",
+    "  https://pytorch-lightning.readthedocs.io/en/stable/advanced/profiler.html\"\"\"\n",
+    "\n",
+    "  def __init__(self, profiler):\n",
+    "    super().__init__()\n",
+    "    self.profiler = profiler \n",
+    "\n",
+    "  def on_train_batch_end(self, trainer, pl_module, outputs, *args, **kwargs):\n",
+    "    self.profiler.step()\n",
+    "    pl_module.log_dict(outputs)  # also logging the loss, while we're here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Run Profiled Training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We're now ready to go!\n",
+    "\n",
+    "The cell below creates a `DataLoader`\n",
+    "based on the information in the `config`uration dictionary.\n",
+    "Choices made here have a substantial impact on performance\n",
+    "and show up very markedly in the trace.\n",
+    "\n",
+    "After you've run with the default values,\n",
+    "check out the creation of the `trainloader`\n",
+    "and the `trainer`\n",
+    "for comments on what these arguments do\n",
+    "and then try a few different choices out, as suggested below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# initial values are defaults, for all except batch_size, which has no default\n",
+    "config = {\"batch_size\": 32,  # try log-spaced values from 1 to 50,000\n",
+    "          \"num_workers\": 0,  # try 0, 1, and 2\n",
+    "          \"pin_memory\": False,  # try False and True\n",
+    "          \"precision\": 32,  # try 16 and 32\n",
+    "          \"optimizer\": \"Adadelta\",  # try optim.Adadelta and optim.SGD\n",
+    "          }\n",
+    "\n",
+    "with wandb.init(project=\"trace\", config=config) as run:\n",
+    "\n",
+    "    # Set up MNIST data\n",
+    "    transform=transforms.Compose([\n",
+    "        transforms.ToTensor(),\n",
+    "        transforms.Normalize((0.1307,), (0.3081,))\n",
+    "        ])\n",
+    "\n",
+    "    dataset = datasets.MNIST(\"../data\", train=True, download=True,\n",
+    "                            transform=transform)\n",
+    "\n",
+    "    ## Using a raw DataLoader, rather than LightningDataModule, for greater transparency\n",
+    "    trainloader = torch.utils.data.DataLoader(\n",
+    "      dataset,\n",
+    "      # Key performance-relevant configuration parameters:\n",
+    "      ## batch_size: how many datapoints are passed through the network at once?\n",
+    "      batch_size=wandb.config.batch_size,\n",
+    "      # larger batch sizes are more compute efficient, up to memory constraints\n",
+    "\n",
+    "      ##  num_workers: how many side processes to launch for dataloading (should be >0)\n",
+    "      num_workers=wandb.config.num_workers,\n",
+    "      # needs to be tuned given model/batch size/compute\n",
+    "\n",
+    "      ## pin_memory: should a fixed \"pinned\" memory block be allocated on the CPU?\n",
+    "      pin_memory=wandb.config.pin_memory,\n",
+    "      # should nearly always be True for GPU models, see https://developer.nvidia.com/blog/how-optimize-data-transfers-cuda-cc/\n",
+    "      )\n",
+    "    \n",
+    "    # Set up model\n",
+    "    model = Net(optimizer=wandb.config[\"optimizer\"])\n",
+    "\n",
+    "    # Set up profiler\n",
+    "    wait, warmup, active, repeat = 1, 1, 2, 1\n",
+    "    total_steps = (wait + warmup + active) * (1 + repeat)\n",
+    "    schedule =  torch.profiler.schedule(\n",
+    "      wait=wait, warmup=warmup, active=active, repeat=repeat)\n",
+    "    profiler = torch.profiler.profile(\n",
+    "      schedule=schedule, on_trace_ready=tensorboard_trace_handler(\"wandb/latest-run/tbprofile\"), with_stack=False)\n",
+    "\n",
+    "    with profiler:\n",
+    "        profiler_callback = TorchTensorboardProfilerCallback(profiler)\n",
+    "\n",
+    "        trainer = pl.Trainer(gpus=1, max_epochs=1, max_steps=total_steps,\n",
+    "                            logger=pl.loggers.WandbLogger(log_model=True, save_code=True),\n",
+    "                            callbacks=[profiler_callback], precision=wandb.config.precision)\n",
+    "\n",
+    "        trainer.fit(model, trainloader)\n",
+    "\n",
+    "    profile_art = wandb.Artifact(f\"trace-{wandb.run.id}\", type=\"profile\")\n",
+    "    profile_art.add_file(glob.glob(\"wandb/latest-run/tbprofile/*.pt.trace.json\")[0], \"trace.pt.trace.json\")\n",
+    "    run.log_artifact(profile_art)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Reading Profiling Results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Head to the Artifacts tab\n",
+    "(identified by the\n",
+    "[\"stacked pucks\"](https://stackoverflow.com/questions/2822650/why-is-a-database-always-represented-with-a-cylinder)\n",
+    "database icon)\n",
+    "for your W&B [run page](https://docs.wandb.ai/ref/app/pages/run-page),\n",
+    "at the URL that appears in the output of the cell above,\n",
+    "then select the artifact named `trace-`.\n",
+    "In the Files tab, select `trace.pt.trace.json`\n",
+    "to pull up the Trace Viewer.\n",
+    "\n",
+    "> You can also check out an example from an earlier run\n",
+    "[here](https://wandb.ai/wandb/trace/artifacts/profile/trace-224bfvza/56c5d50902233baa7710/files/trace.pt.trace.json)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The trace shows which operations were running and when\n",
+    "in each process/thread/stream\n",
+    "on the CPU and on the GPU.\n",
+    "\n",
+    "In the main thread (the one in which the Profiler Steps appear),\n",
+    "locate the following steps:\n",
+    "1. the loading of data (hint: look for `enumerate` on the CPU, nothing on the GPU)\n",
+    "2. the forward pass to calculate the loss (hint: look for simultaneous activity on CPU+GPU,\n",
+    "with [`aten`](https://pytorch.org/cppdocs/#aten) in the operation names)\n",
+    "3. the backward pass to calculate the gradient of the loss (hint: look for simultaneous activity on CPU+GPU, with [`backward`](https://pytorch.org/cppdocs/#autograd) in the operation names).\n",
+    "\n",
+    "If you ran with the default settings\n",
+    "(in particular, `num_workers=0`),\n",
+    "you'll notice that these steps are all run sequentially,\n",
+    "meaning that between loading one batch\n",
+    "and loading the next,\n",
+    "the `DataLoader` is effectively idling,\n",
+    "and during the loading of a batch, the GPU is idling.\n",
+    "\n",
+    "Change `num_workers` in the config to `1` or `2`\n",
+    "and then re-execute the cell above.\n",
+    "You should notice a difference,\n",
+    "in particular in the fraction of time the GPU is active.\n",
+    "(Note: the `DataLoader` may even be hard to find in this case!)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For more on how to read these results, check out\n",
+    "[this W&B Report](http://wandb.me/trace-report)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/colabs/pytorch-lightning/Profile_PyTorch_Code.ipynb
+++ b/colabs/pytorch-lightning/Profile_PyTorch_Code.ipynb
@@ -1,446 +1,486 @@
 {
- "accelerator": "GPU",
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "a05d74c0",
-   "metadata": {
-    "colab_type": "text",
-    "id": "view-in-github"
-   },
-   "source": [
-    "<a href=\"https://colab.research.google.com/github/wandb/examples/blob/master/colabs/pytorch-lightning/Profile_PyTorch_Code.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>",
-    "<!--- @wandbcode{trace-colab} -->"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "h8sLHlDHRXXz"
+      },
+      "source": [
+        "<img src=\"https://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+        "\n",
+        "<!--- @wandbcode{trace-colab} -->\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "7YtSr2DLRXX5"
+      },
+      "source": [
+        "# Profiling PyTorch Code"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ULFmaZBZRXX6"
+      },
+      "source": [
+        "This notebook demonstrates how to incorporate [PyTorch Kineto](https://github.com/pytorch/kineto)'s\n",
+        "[Tensorboard plugin](https://github.com/pytorch/kineto/blob/master/tb_plugin/README.md)\n",
+        "for profiling PyTorch code\n",
+        "with [PyTorch Lightning](https://pytorch-lightning.readthedocs.io/)\n",
+        "as the high-level training API\n",
+        "and\n",
+        "[Weights & Biases](https://wandb.ai/site)\n",
+        "as the logging solution.\n",
+        "\n",
+        "The final result looks something like what you see below:"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "M7rCJNjtRXX7"
+      },
+      "source": [
+        "![](https://i.imgur.com/fwSc5Z9.png)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "6MJoxj-0RXX7"
+      },
+      "source": [
+        "The work done by processes, threads, and streams on the CPU and GPU\n",
+        "is displayed along with precise timing information\n",
+        "in an interactive viewer that can be incorporated into\n",
+        "Weights & Biases\n",
+        "[workspaces](https://docs.wandb.ai/ref/app/pages/workspaces)\n",
+        "and [Reports](https://docs.wandb.ai/guides/reports)\n",
+        "or exported to external viewers."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-SW90DCrRXX8"
+      },
+      "source": [
+        "That means you can incorporate tracing and profiling into\n",
+        "your model training and evaluation pipeline --\n",
+        "storing, visualizing, and communicating\n",
+        "performance results alongside other key metrics and metadata,\n",
+        "like [loss curves](https://docs.wandb.ai/guides/track/log),\n",
+        "[hard examples from datasets](https://docs.wandb.ai/guides/data-vis),\n",
+        "and [hyperparameter optimization results](https://docs.wandb.ai/guides/sweeps)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "t55PmFVJRXX8"
+      },
+      "source": [
+        "> _NB:_ This tool is based on the\n",
+        "[Chrome Trace Viewer](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool),\n",
+        "which works best with that browser."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ZC0EdJBpRXX9"
+      },
+      "outputs": [],
+      "source": [
+        "%%capture\n",
+        "!pip install wandb pytorch_lightning torch_tb_profiler"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "OgO1Yh1-RXX_"
+      },
+      "outputs": [],
+      "source": [
+        "import glob\n",
+        "\n",
+        "import pytorch_lightning as pl\n",
+        "import torch\n",
+        "import torch.nn as nn\n",
+        "import torch.nn.functional as F\n",
+        "import torch.optim as optim\n",
+        "import torchvision\n",
+        "from torchvision import datasets, transforms\n",
+        "\n",
+        "from torch.profiler import tensorboard_trace_handler\n",
+        "import wandb\n",
+        "\n",
+        "# drop slow mirror from list of MNIST mirrors\n",
+        "torchvision.datasets.MNIST.mirrors = [mirror for mirror in torchvision.datasets.MNIST.mirrors\n",
+        "                                      if not mirror.startswith(\"http://yann.lecun.com\")]\n",
+        "                                      \n",
+        "# login to W&B\n",
+        "wandb.login()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "QAt34DIIRXYA"
+      },
+      "source": [
+        "# Set Up Profiled Training"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MbakotteRXYA"
+      },
+      "source": [
+        "## Network Module"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "JBqe-SUNRXYB"
+      },
+      "source": [
+        "To profile neural network code,\n",
+        "we first need to write it.\n",
+        "\n",
+        "For this demo,\n",
+        "we'll stick with a simple\n",
+        "[LeNet](http://yann.lecun.com/exdb/lenet/)-style DNN,\n",
+        "based on the\n",
+        "[PyTorch introductory tutorial](https://pytorch.org/tutorials/recipes/recipes/defining_a_neural_network.html)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "11cy0sWORXYB"
+      },
+      "outputs": [],
+      "source": [
+        "OPTIMIZERS = {\n",
+        "    \"Adadelta\": optim.Adadelta,\n",
+        "    \"Adagrad\" : optim.Adagrad,\n",
+        "    \"SGD\": optim.SGD,\n",
+        "}\n",
+        "\n",
+        "class Net(pl.LightningModule):\n",
+        "  \"\"\"Very simple LeNet-style DNN, plus DropOut.\"\"\"\n",
+        "\n",
+        "  def __init__(self, optimizer=\"Adadelta\"):\n",
+        "    super(Net, self).__init__()\n",
+        "    self.conv1 = nn.Conv2d(1, 32, 3, 1)\n",
+        "    self.conv2 = nn.Conv2d(32, 64, 3, 1)\n",
+        "    self.dropout1 = nn.Dropout(0.25)\n",
+        "    self.dropout2 = nn.Dropout(0.5)\n",
+        "    self.fc1 = nn.Linear(9216, 128)\n",
+        "    self.fc2 = nn.Linear(128, 10)\n",
+        "\n",
+        "    self.optimizer = self.set_optimizer(optimizer)\n",
+        "\n",
+        "  def forward(self, x):\n",
+        "    x = self.conv1(x)\n",
+        "    x = F.relu(x)\n",
+        "    x = self.conv2(x)\n",
+        "    x = F.relu(x)\n",
+        "    x = F.max_pool2d(x, 2)\n",
+        "    x = self.dropout1(x)\n",
+        "    x = torch.flatten(x, 1)\n",
+        "    x = self.fc1(x)\n",
+        "    x = F.relu(x)\n",
+        "    x = self.dropout2(x)\n",
+        "    x = self.fc2(x)\n",
+        "    output = F.log_softmax(x, dim=1)\n",
+        "    return output\n",
+        "\n",
+        "  def set_optimizer(self, optimizer):\n",
+        "    return OPTIMIZERS[optimizer]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "QLDjJYvjRXYC"
+      },
+      "source": [
+        "To get this module to work with PyTorch Lightning,\n",
+        "we need to define two more methods,\n",
+        "which hook into the training loop.\n",
+        "\n",
+        "Check out [this tutorial video and notebook](http://wandb.me/lit-video)\n",
+        "for more on using PyTorch Lightning and W&B."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "xS1ZLJdCRXYC"
+      },
+      "outputs": [],
+      "source": [
+        "def training_step(self, batch, idx):\n",
+        "  inputs, labels = batch\n",
+        "  outputs = self(inputs)\n",
+        "  loss =  F.nll_loss(outputs, labels)\n",
+        "\n",
+        "  return {\"loss\": loss}\n",
+        "    \n",
+        "def configure_optimizers(self):\n",
+        "  return self.optimizer(self.parameters(), lr=0.1)\n",
+        "\n",
+        "Net.training_step = training_step\n",
+        "Net.configure_optimizers = configure_optimizers"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "5LX9yFEeRXYD"
+      },
+      "source": [
+        "## Profiler Callback"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "wxXMljOMRXYD"
+      },
+      "source": [
+        "The profiler operates a bit like a PyTorch optimizer:\n",
+        "it has a `.step` method that we need to call\n",
+        "to demarcate the code we're interested in profiling.\n",
+        "\n",
+        "A single training step (forward and backward prop)\n",
+        "is both the typical target of performance optimizations\n",
+        "and already rich enough to more than fill out a profiling trace,\n",
+        "so we want to call `.step` on each step.\n",
+        "\n",
+        "The cell below defines a quick-and-dirty\n",
+        "method for doing so in PyTorch Lightning using the\n",
+        "[`Callback` system](https://pytorch-lightning.readthedocs.io/en/stable/extensions/callbacks.html)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "tVoEwPJ0RXYE"
+      },
+      "outputs": [],
+      "source": [
+        "class TorchTensorboardProfilerCallback(pl.Callback):\n",
+        "  \"\"\"Quick-and-dirty Callback for invoking TensorboardProfiler during training.\n",
+        "  \n",
+        "  For greater robustness, extend the pl.profiler.profilers.BaseProfiler. See\n",
+        "  https://pytorch-lightning.readthedocs.io/en/stable/advanced/profiler.html\"\"\"\n",
+        "\n",
+        "  def __init__(self, profiler):\n",
+        "    super().__init__()\n",
+        "    self.profiler = profiler \n",
+        "\n",
+        "  def on_train_batch_end(self, trainer, pl_module, outputs, *args, **kwargs):\n",
+        "    self.profiler.step()\n",
+        "    pl_module.log_dict(outputs)  # also logging the loss, while we're here"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "H-3ONoF0RXYE"
+      },
+      "source": [
+        "# Run Profiled Training"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "WLgdOE2WRXYE"
+      },
+      "source": [
+        "We're now ready to go!\n",
+        "\n",
+        "The cell below creates a `DataLoader`\n",
+        "based on the information in the `config`uration dictionary.\n",
+        "Choices made here have a substantial impact on performance\n",
+        "and show up very markedly in the trace.\n",
+        "\n",
+        "After you've run with the default values,\n",
+        "check out the creation of the `trainloader`\n",
+        "and the `trainer`\n",
+        "for comments on what these arguments do\n",
+        "and then try a few different choices out, as suggested below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ZhtHzOgsRXYE"
+      },
+      "outputs": [],
+      "source": [
+        "# initial values are defaults, for all except batch_size, which has no default\n",
+        "config = {\"batch_size\": 32,  # try log-spaced values from 1 to 50,000\n",
+        "          \"num_workers\": 0,  # try 0, 1, and 2\n",
+        "          \"pin_memory\": False,  # try False and True\n",
+        "          \"precision\": 32,  # try 16 and 32\n",
+        "          \"optimizer\": \"Adadelta\",  # try optim.Adadelta and optim.SGD\n",
+        "          }\n",
+        "\n",
+        "with wandb.init(project=\"trace\", config=config) as run:\n",
+        "\n",
+        "    # Set up MNIST data\n",
+        "    transform=transforms.Compose([\n",
+        "        transforms.ToTensor(),\n",
+        "        transforms.Normalize((0.1307,), (0.3081,))\n",
+        "        ])\n",
+        "\n",
+        "    dataset = datasets.MNIST(\"../data\", train=True, download=True,\n",
+        "                            transform=transform)\n",
+        "\n",
+        "    ## Using a raw DataLoader, rather than LightningDataModule, for greater transparency\n",
+        "    trainloader = torch.utils.data.DataLoader(\n",
+        "      dataset,\n",
+        "      # Key performance-relevant configuration parameters:\n",
+        "      ## batch_size: how many datapoints are passed through the network at once?\n",
+        "      batch_size=wandb.config.batch_size,\n",
+        "      # larger batch sizes are more compute efficient, up to memory constraints\n",
+        "\n",
+        "      ##  num_workers: how many side processes to launch for dataloading (should be >0)\n",
+        "      num_workers=wandb.config.num_workers,\n",
+        "      # needs to be tuned given model/batch size/compute\n",
+        "\n",
+        "      ## pin_memory: should a fixed \"pinned\" memory block be allocated on the CPU?\n",
+        "      pin_memory=wandb.config.pin_memory,\n",
+        "      # should nearly always be True for GPU models, see https://developer.nvidia.com/blog/how-optimize-data-transfers-cuda-cc/\n",
+        "      )\n",
+        "    \n",
+        "    # Set up model\n",
+        "    model = Net(optimizer=wandb.config[\"optimizer\"])\n",
+        "\n",
+        "    # Set up profiler\n",
+        "    wait, warmup, active, repeat = 1, 1, 2, 1\n",
+        "    total_steps = (wait + warmup + active) * (1 + repeat)\n",
+        "    schedule =  torch.profiler.schedule(\n",
+        "      wait=wait, warmup=warmup, active=active, repeat=repeat)\n",
+        "    profiler = torch.profiler.profile(\n",
+        "      schedule=schedule, on_trace_ready=tensorboard_trace_handler(\"wandb/latest-run/tbprofile\"), with_stack=False)\n",
+        "\n",
+        "    with profiler:\n",
+        "        profiler_callback = TorchTensorboardProfilerCallback(profiler)\n",
+        "\n",
+        "        trainer = pl.Trainer(gpus=1, max_epochs=1, max_steps=total_steps,\n",
+        "                            logger=pl.loggers.WandbLogger(log_model=True, save_code=True),\n",
+        "                            callbacks=[profiler_callback], precision=wandb.config.precision)\n",
+        "\n",
+        "        trainer.fit(model, trainloader)\n",
+        "\n",
+        "    profile_art = wandb.Artifact(f\"trace-{wandb.run.id}\", type=\"profile\")\n",
+        "    profile_art.add_file(glob.glob(\"wandb/latest-run/tbprofile/*.pt.trace.json\")[0], \"trace.pt.trace.json\")\n",
+        "    run.log_artifact(profile_art)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "U-rRWZ8IRXYF"
+      },
+      "source": [
+        "# Reading Profiling Results"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "WL5dvLdsRXYF"
+      },
+      "source": [
+        "Head to the Artifacts tab\n",
+        "(identified by the\n",
+        "[\"stacked pucks\"](https://stackoverflow.com/questions/2822650/why-is-a-database-always-represented-with-a-cylinder)\n",
+        "database icon)\n",
+        "for your W&B [run page](https://docs.wandb.ai/ref/app/pages/run-page),\n",
+        "at the URL that appears in the output of the cell above,\n",
+        "then select the artifact named `trace-`.\n",
+        "In the Files tab, select `trace.pt.trace.json`\n",
+        "to pull up the Trace Viewer.\n",
+        "\n",
+        "> You can also check out an example from an earlier run\n",
+        "[here](https://wandb.ai/wandb/trace/artifacts/profile/trace-224bfvza/56c5d50902233baa7710/files/trace.pt.trace.json)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Rgv1l4vcRXYG"
+      },
+      "source": [
+        "The trace shows which operations were running and when\n",
+        "in each process/thread/stream\n",
+        "on the CPU and on the GPU.\n",
+        "\n",
+        "In the main thread (the one in which the Profiler Steps appear),\n",
+        "locate the following steps:\n",
+        "1. the loading of data (hint: look for `enumerate` on the CPU, nothing on the GPU)\n",
+        "2. the forward pass to calculate the loss (hint: look for simultaneous activity on CPU+GPU,\n",
+        "with [`aten`](https://pytorch.org/cppdocs/#aten) in the operation names)\n",
+        "3. the backward pass to calculate the gradient of the loss (hint: look for simultaneous activity on CPU+GPU, with [`backward`](https://pytorch.org/cppdocs/#autograd) in the operation names).\n",
+        "\n",
+        "If you ran with the default settings\n",
+        "(in particular, `num_workers=0`),\n",
+        "you'll notice that these steps are all run sequentially,\n",
+        "meaning that between loading one batch\n",
+        "and loading the next,\n",
+        "the `DataLoader` is effectively idling,\n",
+        "and during the loading of a batch, the GPU is idling.\n",
+        "\n",
+        "Change `num_workers` in the config to `1` or `2`\n",
+        "and then re-execute the cell above.\n",
+        "You should notice a difference,\n",
+        "in particular in the fraction of time the GPU is active.\n",
+        "(Note: the `DataLoader` may even be hard to find in this case!)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "37rtD08FRXYG"
+      },
+      "source": [
+        "For more on how to read these results, check out\n",
+        "[this W&B Report](http://wandb.me/trace-report)."
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "toc_visible": true,
+      "name": "Profile_PyTorch_Code.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "accelerator": "GPU",
+    "gpuClass": "standard"
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<img src=\"https://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
-    "\n",
-    "<!--- @wandbcode{trace-colab} -->\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Profiling PyTorch Code"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This notebook demonstrates how to incorporate [PyTorch Kineto](https://github.com/pytorch/kineto)'s\n",
-    "[Tensorboard plugin](https://github.com/pytorch/kineto/blob/master/tb_plugin/README.md)\n",
-    "for profiling PyTorch code\n",
-    "with [PyTorch Lightning](https://pytorch-lightning.readthedocs.io/)\n",
-    "as the high-level training API\n",
-    "and\n",
-    "[Weights & Biases](https://wandb.ai/site)\n",
-    "as the logging solution.\n",
-    "\n",
-    "The final result looks something like what you see below:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "![](https://i.imgur.com/fwSc5Z9.png)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The work done by processes, threads, and streams on the CPU and GPU\n",
-    "is displayed along with precise timing information\n",
-    "in an interactive viewer that can be incorporated into\n",
-    "Weights & Biases\n",
-    "[workspaces](https://docs.wandb.ai/ref/app/pages/workspaces)\n",
-    "and [Reports](https://docs.wandb.ai/guides/reports)\n",
-    "or exported to external viewers."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "That means you can incorporate tracing and profiling into\n",
-    "your model training and evaluation pipeline --\n",
-    "storing, visualizing, and communicating\n",
-    "performance results alongside other key metrics and metadata,\n",
-    "like [loss curves](https://docs.wandb.ai/guides/track/log),\n",
-    "[hard examples from datasets](https://docs.wandb.ai/guides/data-vis),\n",
-    "and [hyperparameter optimization results](https://docs.wandb.ai/guides/sweeps)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "> _NB:_ This tool is based on the\n",
-    "[Chrome Trace Viewer](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool),\n",
-    "which works best with that browser."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%capture\n",
-    "!pip install wandb pytorch_lightning torch_tb_profiler"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import glob\n",
-    "\n",
-    "import pytorch_lightning as pl\n",
-    "import torch\n",
-    "import torch.nn as nn\n",
-    "import torch.nn.functional as F\n",
-    "import torch.optim as optim\n",
-    "import torchvision\n",
-    "from torchvision import datasets, transforms\n",
-    "\n",
-    "from torch.profiler import tensorboard_trace_handler\n",
-    "import wandb\n",
-    "\n",
-    "# drop slow mirror from list of MNIST mirrors\n",
-    "torchvision.datasets.MNIST.mirrors = [mirror for mirror in torchvision.datasets.MNIST.mirrors\n",
-    "                                      if not mirror.startswith(\"http://yann.lecun.com\")]\n",
-    "                                      \n",
-    "# login to W&B\n",
-    "wandb.login()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Set Up Profiled Training"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Network Module"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To profile neural network code,\n",
-    "we first need to write it.\n",
-    "\n",
-    "For this demo,\n",
-    "we'll stick with a simple\n",
-    "[LeNet](http://yann.lecun.com/exdb/lenet/)-style DNN,\n",
-    "based on the\n",
-    "[PyTorch introductory tutorial](https://pytorch.org/tutorials/recipes/recipes/defining_a_neural_network.html)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "OPTIMIZERS = {\n",
-    "    \"Adadelta\": optim.Adadelta,\n",
-    "    \"Adagrad\" : optim.Adagrad,\n",
-    "    \"SGD\": optim.SGD,\n",
-    "}\n",
-    "\n",
-    "class Net(pl.LightningModule):\n",
-    "  \"\"\"Very simple LeNet-style DNN, plus DropOut.\"\"\"\n",
-    "\n",
-    "  def __init__(self, optimizer=\"Adadelta\"):\n",
-    "    super(Net, self).__init__()\n",
-    "    self.conv1 = nn.Conv2d(1, 32, 3, 1)\n",
-    "    self.conv2 = nn.Conv2d(32, 64, 3, 1)\n",
-    "    self.dropout1 = nn.Dropout(0.25)\n",
-    "    self.dropout2 = nn.Dropout(0.5)\n",
-    "    self.fc1 = nn.Linear(9216, 128)\n",
-    "    self.fc2 = nn.Linear(128, 10)\n",
-    "\n",
-    "    self.optimizer = self.set_optimizer(optimizer)\n",
-    "\n",
-    "  def forward(self, x):\n",
-    "    x = self.conv1(x)\n",
-    "    x = F.relu(x)\n",
-    "    x = self.conv2(x)\n",
-    "    x = F.relu(x)\n",
-    "    x = F.max_pool2d(x, 2)\n",
-    "    x = self.dropout1(x)\n",
-    "    x = torch.flatten(x, 1)\n",
-    "    x = self.fc1(x)\n",
-    "    x = F.relu(x)\n",
-    "    x = self.dropout2(x)\n",
-    "    x = self.fc2(x)\n",
-    "    output = F.log_softmax(x, dim=1)\n",
-    "    return output\n",
-    "\n",
-    "  def set_optimizer(self, optimizer):\n",
-    "    return OPTIMIZERS[optimizer]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To get this module to work with PyTorch Lightning,\n",
-    "we need to define two more methods,\n",
-    "which hook into the training loop.\n",
-    "\n",
-    "Check out [this tutorial video and notebook](http://wandb.me/lit-video)\n",
-    "for more on using PyTorch Lightning and W&B."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def training_step(self, batch, idx):\n",
-    "  inputs, labels = batch\n",
-    "  outputs = self(inputs)\n",
-    "  loss =  F.nll_loss(outputs, labels)\n",
-    "\n",
-    "  return {\"loss\": loss}\n",
-    "    \n",
-    "def configure_optimizers(self):\n",
-    "  return self.optimizer(self.parameters(), lr=0.1)\n",
-    "\n",
-    "Net.training_step = training_step\n",
-    "Net.configure_optimizers = configure_optimizers"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Profiler Callback"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The profiler operates a bit like a PyTorch optimizer:\n",
-    "it has a `.step` method that we need to call\n",
-    "to demarcate the code we're interested in profiling.\n",
-    "\n",
-    "A single training step (forward and backward prop)\n",
-    "is both the typical target of performance optimizations\n",
-    "and already rich enough to more than fill out a profiling trace,\n",
-    "so we want to call `.step` on each step.\n",
-    "\n",
-    "The cell below defines a quick-and-dirty\n",
-    "method for doing so in PyTorch Lightning using the\n",
-    "[`Callback` system](https://pytorch-lightning.readthedocs.io/en/stable/extensions/callbacks.html)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "class TorchTensorboardProfilerCallback(pl.Callback):\n",
-    "  \"\"\"Quick-and-dirty Callback for invoking TensorboardProfiler during training.\n",
-    "  \n",
-    "  For greater robustness, extend the pl.profiler.profilers.BaseProfiler. See\n",
-    "  https://pytorch-lightning.readthedocs.io/en/stable/advanced/profiler.html\"\"\"\n",
-    "\n",
-    "  def __init__(self, profiler):\n",
-    "    super().__init__()\n",
-    "    self.profiler = profiler \n",
-    "\n",
-    "  def on_train_batch_end(self, trainer, pl_module, outputs, *args, **kwargs):\n",
-    "    self.profiler.step()\n",
-    "    pl_module.log_dict(outputs)  # also logging the loss, while we're here"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Run Profiled Training"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We're now ready to go!\n",
-    "\n",
-    "The cell below creates a `DataLoader`\n",
-    "based on the information in the `config`uration dictionary.\n",
-    "Choices made here have a substantial impact on performance\n",
-    "and show up very markedly in the trace.\n",
-    "\n",
-    "After you've run with the default values,\n",
-    "check out the creation of the `trainloader`\n",
-    "and the `trainer`\n",
-    "for comments on what these arguments do\n",
-    "and then try a few different choices out, as suggested below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# initial values are defaults, for all except batch_size, which has no default\n",
-    "config = {\"batch_size\": 32,  # try log-spaced values from 1 to 50,000\n",
-    "          \"num_workers\": 0,  # try 0, 1, and 2\n",
-    "          \"pin_memory\": False,  # try False and True\n",
-    "          \"precision\": 32,  # try 16 and 32\n",
-    "          \"optimizer\": \"Adadelta\",  # try optim.Adadelta and optim.SGD\n",
-    "          }\n",
-    "\n",
-    "with wandb.init(project=\"trace\", config=config) as run:\n",
-    "\n",
-    "    # Set up MNIST data\n",
-    "    transform=transforms.Compose([\n",
-    "        transforms.ToTensor(),\n",
-    "        transforms.Normalize((0.1307,), (0.3081,))\n",
-    "        ])\n",
-    "\n",
-    "    dataset = datasets.MNIST(\"../data\", train=True, download=True,\n",
-    "                            transform=transform)\n",
-    "\n",
-    "    ## Using a raw DataLoader, rather than LightningDataModule, for greater transparency\n",
-    "    trainloader = torch.utils.data.DataLoader(\n",
-    "      dataset,\n",
-    "      # Key performance-relevant configuration parameters:\n",
-    "      ## batch_size: how many datapoints are passed through the network at once?\n",
-    "      batch_size=wandb.config.batch_size,\n",
-    "      # larger batch sizes are more compute efficient, up to memory constraints\n",
-    "\n",
-    "      ##  num_workers: how many side processes to launch for dataloading (should be >0)\n",
-    "      num_workers=wandb.config.num_workers,\n",
-    "      # needs to be tuned given model/batch size/compute\n",
-    "\n",
-    "      ## pin_memory: should a fixed \"pinned\" memory block be allocated on the CPU?\n",
-    "      pin_memory=wandb.config.pin_memory,\n",
-    "      # should nearly always be True for GPU models, see https://developer.nvidia.com/blog/how-optimize-data-transfers-cuda-cc/\n",
-    "      )\n",
-    "    \n",
-    "    # Set up model\n",
-    "    model = Net(optimizer=wandb.config[\"optimizer\"])\n",
-    "\n",
-    "    # Set up profiler\n",
-    "    wait, warmup, active, repeat = 1, 1, 2, 1\n",
-    "    total_steps = (wait + warmup + active) * (1 + repeat)\n",
-    "    schedule =  torch.profiler.schedule(\n",
-    "      wait=wait, warmup=warmup, active=active, repeat=repeat)\n",
-    "    profiler = torch.profiler.profile(\n",
-    "      schedule=schedule, on_trace_ready=tensorboard_trace_handler(\"wandb/latest-run/tbprofile\"), with_stack=True)\n",
-    "\n",
-    "    with profiler:\n",
-    "        profiler_callback = TorchTensorboardProfilerCallback(profiler)\n",
-    "\n",
-    "        trainer = pl.Trainer(gpus=1, max_epochs=1, max_steps=total_steps,\n",
-    "                            logger=pl.loggers.WandbLogger(log_model=True, save_code=True),\n",
-    "                            callbacks=[profiler_callback], precision=wandb.config.precision)\n",
-    "\n",
-    "        trainer.fit(model, trainloader)\n",
-    "\n",
-    "    profile_art = wandb.Artifact(f\"trace-{wandb.run.id}\", type=\"profile\")\n",
-    "    profile_art.add_file(glob.glob(\"wandb/latest-run/tbprofile/*.pt.trace.json\")[0], \"trace.pt.trace.json\")\n",
-    "    run.log_artifact(profile_art)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Reading Profiling Results"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Head to the Artifacts tab\n",
-    "(identified by the\n",
-    "[\"stacked pucks\"](https://stackoverflow.com/questions/2822650/why-is-a-database-always-represented-with-a-cylinder)\n",
-    "database icon)\n",
-    "for your W&B [run page](https://docs.wandb.ai/ref/app/pages/run-page),\n",
-    "at the URL that appears in the output of the cell above,\n",
-    "then select the artifact named `trace-`.\n",
-    "In the Files tab, select `trace.pt.trace.json`\n",
-    "to pull up the Trace Viewer.\n",
-    "\n",
-    "> You can also check out an example from an earlier run\n",
-    "[here](https://wandb.ai/wandb/trace/artifacts/profile/trace-224bfvza/56c5d50902233baa7710/files/trace.pt.trace.json)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The trace shows which operations were running and when\n",
-    "in each process/thread/stream\n",
-    "on the CPU and on the GPU.\n",
-    "\n",
-    "In the main thread (the one in which the Profiler Steps appear),\n",
-    "locate the following steps:\n",
-    "1. the loading of data (hint: look for `enumerate` on the CPU, nothing on the GPU)\n",
-    "2. the forward pass to calculate the loss (hint: look for simultaneous activity on CPU+GPU,\n",
-    "with [`aten`](https://pytorch.org/cppdocs/#aten) in the operation names)\n",
-    "3. the backward pass to calculate the gradient of the loss (hint: look for simultaneous activity on CPU+GPU, with [`backward`](https://pytorch.org/cppdocs/#autograd) in the operation names).\n",
-    "\n",
-    "If you ran with the default settings\n",
-    "(in particular, `num_workers=0`),\n",
-    "you'll notice that these steps are all run sequentially,\n",
-    "meaning that between loading one batch\n",
-    "and loading the next,\n",
-    "the `DataLoader` is effectively idling,\n",
-    "and during the loading of a batch, the GPU is idling.\n",
-    "\n",
-    "Change `num_workers` in the config to `1` or `2`\n",
-    "and then re-execute the cell above.\n",
-    "You should notice a difference,\n",
-    "in particular in the fraction of time the GPU is active.\n",
-    "(Note: the `DataLoader` may even be hard to find in this case!)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "For more on how to read these results, check out\n",
-    "[this W&B Report](http://wandb.me/trace-report)."
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "include_colab_link": true,
-   "toc_visible": true
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "name": "python3"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 0
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
The profiling Colab (Profile PyTorch Code, under the Lightning colabs) currently crashes because of a change to the behavior of the PyTorch profiler in recent versions that massively increases the weight of logs that include stack traces.

This PR turns off stack trace logging by setting `with_stack=False` in L383 and avoids the crash.