### PR TITLE
Updating examples to remove warnings

### DIFF
--- a/examples/scikit/scikit-classification/train.py
+++ b/examples/scikit/scikit-classification/train.py
@@ -19,11 +19,11 @@ labels = ['one', 'two', 'three', 'four', 'five',
 
 # Train model
 model = RandomForestClassifier()
-model.fit(X, y)
+model.fit(X.values, y)
 
 # Get predictions
-y_pred = model.predict(X_test)
-y_probas = model.predict_proba(X_test)
+y_pred = model.predict(X_test.values)
+y_probas = model.predict_proba(X_test.values)
 importances = model.feature_importances_
 indices = np.argsort(importances)[::-1]
 
@@ -31,5 +31,5 @@ print(X_train.info())
 
 # Visualize model performance
 wandb.sklearn.plot_classifier(
-    model, X_train, X_test, y_train, y_test, y_pred, y_probas, labels,
+    model, X_train.values, X_test.values, y_train, y_test, y_pred, y_probas, labels,
     is_binary=False, model_name='RandomForest', feature_names=feature_names)

--- a/examples/scikit/scikit-housing/sklearn_regression.py
+++ b/examples/scikit/scikit-housing/sklearn_regression.py
@@ -15,9 +15,9 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
 
 # Train model, get predictions
 reg = Ridge()
-reg.fit(X, y)
-y_pred = reg.predict(X_test)
+reg.fit(X.values, y)
+y_pred = reg.predict(X_test.values)
 
 # Visualize model performance
-wandb.sklearn.plot_outlier_candidates(reg, X, y)
-wandb.sklearn.plot_residuals(reg, X, y)
+wandb.sklearn.plot_outlier_candidates(reg, X.values, y)
+wandb.sklearn.plot_residuals(reg, X.values, y)

--- a/examples/scikit/scikit-iris/train.py
+++ b/examples/scikit/scikit-iris/train.py
@@ -40,7 +40,7 @@ def plot_data():
     cmap = ListedColormap(colors[:len(np.unique(y_test))])
     for idx, cl in enumerate(np.unique(y)):
         plt.scatter(x=X[y == cl, 0], y=X[y == cl, 1],
-               c=cmap(idx), marker=markers[idx], label=cl)
+               color=cmap(idx), marker=markers[idx], label=cl)
 
     wandb.log({"Data": plt})
 

--- a/examples/scikit/scikit-predict-a-pulsar-star/train.py
+++ b/examples/scikit/scikit-predict-a-pulsar-star/train.py
@@ -69,12 +69,12 @@ adaboost = AdaBoostClassifier(n_estimators=500, learning_rate=0.01, random_state
                              min_samples_leaf=10, random_state=42))
 
 def model_algorithm(clf, X_train, y_train, X_test, y_test, name, labels, features):
-    clf.fit(X_train, y_train)
-    y_probas = clf.predict_proba(X_test)
+    clf.fit(X_train.values, y_train)
+    y_probas = clf.predict_proba(X_test.values)
     y_pred = clf.predict(X_test)
     wandb.init(project="visualize-sklearn", name=name, reinit=True)
     # wandb.sklearn.plot_roc(y_test, y_probas, labels, reinit = True)
-    wandb.sklearn.plot_classifier(clf, X_train, X_test, y_train,
+    wandb.sklearn.plot_classifier(clf, X_train.values, X_test.values, y_train,
                     y_test, y_pred, y_probas, labels, True, name, features)
 
 model_algorithm(log, X_train, y_train, X_test, y_test, 'LogisticRegression', labels, features)

--- a/examples/scikit/scikit-tests/test.py
+++ b/examples/scikit/scikit-tests/test.py
@@ -1,8 +1,7 @@
 import pytest
 from sklearn.ensemble import RandomForestClassifier
 import wandb
-from wandb.sklearn import learning_curve
-
+from wandb.sklearn import plot_learning_curve
 # initialize wandb run
 wandb.init(project="test")
 


### PR DESCRIPTION


More Changes:
- [X] `UserWarning` in `sklearn.fit()` when trained with pandas dataframe. <img width="1405" alt="Screenshot%202022-06-13%20at%204 41 14%20PM" src="https://user-images.githubusercontent.com/13994201/175120006-a0dca006-99b2-4922-a160-9bce1d043b9d.png">
- [x] [`scikit-tests/test.py`](examples/scikit/scikit-tests/test.py) is failing.
- [ ] `get_offset_position()` in plotly is deprecated and removed in matplotlib >= 3.4. Causing the integration to fail.
- [ ] `wandb.plots.*` deprecated in favor of `wandb.plot.*` need to update it.

CC: @morganmcg1 