### PR TITLE
Update PL and W&B integration colab notebook

### DIFF
--- a/colabs/pytorch-lightning/Optimize_Pytorch_Lightning_models_with_Weights_&_Biases.ipynb
+++ b/colabs/pytorch-lightning/Optimize_Pytorch_Lightning_models_with_Weights_&_Biases.ipynb
@@ -231,7 +231,7 @@
     "        logits = self(x)\n",
     "        preds = torch.argmax(logits, dim=1)\n",
     "        loss = self.loss(logits, y)\n",
-    "        acc = accuracy(preds, y)\n",
+    "        acc = accuracy(preds, y, 'multiclass', num_classes=10)\n",
     "        return preds, loss, acc"
    ]
   },
@@ -373,6 +373,7 @@
     "    logger=wandb_logger,                    # W&B integration\n",
     "    callbacks=[log_predictions_callback,    # logging of sample predictions\n",
     "               checkpoint_callback],        # our model checkpoint callback\n",
+    "    accelerator='gpu',
     "    max_epochs=5)                           # number of epochs"
    ]
   },


### PR DESCRIPTION
- accuracy from torchmetrics.functional now explicitly requires 'task' and 'num_classes'.
- trainer now requires argument 'accelerator' to be set to 'gpu' for gpu to be used.