### PR TITLE
feat(colabs): Weight Initialization Methods in Tensorflow

### DIFF
--- a/colabs/tensorflow/Tensorflow_Initialization_Methods.ipynb
+++ b/colabs/tensorflow/Tensorflow_Initialization_Methods.ipynb
@@ -1,0 +1,146 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "Tensorflow: Initialization Methods",
+      "provenance": [],
+      "authorship_tag": "ABX9TyM3re1IWj4ZNeW2JZowJuDK",
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/SauravMaheshkar/Initialization/blob/main/Notebooks/Tensorflow_Initialization_Methods.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "CqYwENgjVA_1"
+      },
+      "source": [
+        "# Packages 📦 and Basic Setup"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "d1Q_akW-L4V6"
+      },
+      "source": [
+        "%%capture\n",
+        "!pip install wandb\n",
+        "import wandb\n",
+        "import numpy as np\n",
+        "import tensorflow as tf\n",
+        "from wandb.keras import WandbCallback"
+      ],
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "wVn1Sd8iVtdm"
+      },
+      "source": [
+        "# 💿 Dataset\n",
+        "\n",
+        "For the sake of simplicity, MNIST was chosen"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "smH0Lgo8I6bc"
+      },
+      "source": [
+        "mnist = tf.keras.datasets.mnist\n",
+        "\n",
+        "(x_train, y_train),(x_test, y_test) = mnist.load_data()\n",
+        "x_train, x_test = x_train / 255.0, x_test / 255.0"
+      ],
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "nlbqhgHEVxm1"
+      },
+      "source": [
+        "# The Model 👷‍♀️\n",
+        "\n",
+        "Initializers used (from `tf.keras.initializers`):-\n",
+        "\n",
+        "* Zeros\n",
+        "* LeCunNormal\n",
+        "* GlorotNormal\n",
+        "* HeNormal"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "u7q0vfT7JE95"
+      },
+      "source": [
+        "initializer = tf.keras.initializers.LecunNormal()\n",
+        "\n",
+        "model = tf.keras.models.Sequential([\n",
+        "  tf.keras.layers.Flatten(input_shape=(28, 28)),\n",
+        "  tf.keras.layers.Dense(128, activation='tanh', kernel_initializer=initializer),\n",
+        "  tf.keras.layers.Dense(64, activation='tanh', kernel_initializer=initializer),\n",
+        "  tf.keras.layers.Dense(32, activation='tanh', kernel_initializer=initializer),\n",
+        "  tf.keras.layers.Dense(10, activation='softmax')\n",
+        "])\n",
+        "\n",
+        "model.compile(optimizer='adam',\n",
+        "              loss='sparse_categorical_crossentropy',\n",
+        "              metrics=['accuracy'])"
+      ],
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dK3B6R7nV2Mk"
+      },
+      "source": [
+        "# Training 💪🏻\n",
+        "\n",
+        "The weights and gradients were logged using the helpful `log_gradients` and `log_weights` parameters of `WandbCallback()`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "frvqYNnfK9T8"
+      },
+      "source": [
+        "run = wandb.init()\n",
+        "\n",
+        "model.fit(x_train, y_train, epochs=20, callbacks=[WandbCallback(training_data = (x_train, y_train),log_weights = True, log_gradients = True, save_model = False)])\n",
+        "\n",
+        "run.finish()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/colabs/tensorflow/Tensorflow_Initialization_Methods.ipynb
+++ b/colabs/tensorflow/Tensorflow_Initialization_Methods.ipynb
@@ -1,135 +1,136 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "Tensorflow: Initialization Methods",
-      "provenance": [],
-      "authorship_tag": "ABX9TyM3re1IWj4ZNeW2JZowJuDK"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/wandb/examples/blob/master/colabs/tensorflow/Tensorflow_Initialization_Methods.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "CqYwENgjVA_1"
-      },
-      "source": [
-        "# Packages 📦 and Basic Setup"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "d1Q_akW-L4V6"
-      },
-      "source": [
-        "%%capture\n",
-        "!pip install wandb\n",
-        "import wandb\n",
-        "import numpy as np\n",
-        "import tensorflow as tf\n",
-        "from wandb.keras import WandbCallback"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "wVn1Sd8iVtdm"
-      },
-      "source": [
-        "# 💿 Dataset\n",
-        "\n",
-        "For the sake of simplicity, MNIST was chosen"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "smH0Lgo8I6bc"
-      },
-      "source": [
-        "mnist = tf.keras.datasets.mnist\n",
-        "\n",
-        "(x_train, y_train),(x_test, y_test) = mnist.load_data()\n",
-        "x_train, x_test = x_train / 255.0, x_test / 255.0"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "nlbqhgHEVxm1"
-      },
-      "source": [
-        "# The Model 👷‍♀️\n",
-        "\n",
-        "Initializers used (from `tf.keras.initializers`):-\n",
-        "\n",
-        "* Zeros\n",
-        "* LeCunNormal\n",
-        "* GlorotNormal\n",
-        "* HeNormal"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "u7q0vfT7JE95"
-      },
-      "source": [
-        "initializer = tf.keras.initializers.LecunNormal()\n",
-        "\n",
-        "model = tf.keras.models.Sequential([\n",
-        "  tf.keras.layers.Flatten(input_shape=(28, 28)),\n",
-        "  tf.keras.layers.Dense(128, activation='tanh', kernel_initializer=initializer),\n",
-        "  tf.keras.layers.Dense(64, activation='tanh', kernel_initializer=initializer),\n",
-        "  tf.keras.layers.Dense(32, activation='tanh', kernel_initializer=initializer),\n",
-        "  tf.keras.layers.Dense(10, activation='softmax')\n",
-        "])\n",
-        "\n",
-        "model.compile(optimizer='adam',\n",
-        "              loss='sparse_categorical_crossentropy',\n",
-        "              metrics=['accuracy'])"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dK3B6R7nV2Mk"
-      },
-      "source": [
-        "# Training 💪🏻\n",
-        "\n",
-        "The weights and gradients were logged using the helpful `log_gradients` and `log_weights` parameters of `WandbCallback()`"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "frvqYNnfK9T8"
-      },
-      "source": [
-        "run = wandb.init()\n",
-        "\n",
-        "model.fit(x_train, y_train, epochs=20, callbacks=[WandbCallback(training_data = (x_train, y_train),log_weights = True, log_gradients = True, save_model = False)])\n",
-        "\n",
-        "run.finish()"
-      ],
-      "execution_count": null,
-      "outputs": []
-    }
-  ]
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Packages 📦 and Basic Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "!pip install -Uq wandb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import wandb\n",
+    "import numpy as np\n",
+    "import tensorflow as tf\n",
+    "from wandb.keras import WandbCallback"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 💿 Dataset\n",
+    "\n",
+    "For the sake of simplicity, MNIST was chosen"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mnist = tf.keras.datasets.mnist\n",
+    "\n",
+    "(x_train, y_train),(x_test, y_test) = mnist.load_data()\n",
+    "x_train, x_test = x_train / 255.0, x_test / 255.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# The Model 👷‍♀️\n",
+    "\n",
+    "Initializers used (from `tf.keras.initializers`):-\n",
+    "\n",
+    "* Zeros\n",
+    "* LeCunNormal\n",
+    "* GlorotNormal\n",
+    "* HeNormal"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "initializer = tf.keras.initializers.LecunNormal()\n",
+    "\n",
+    "model = tf.keras.models.Sequential([\n",
+    "  tf.keras.layers.Flatten(input_shape=(28, 28)),\n",
+    "  tf.keras.layers.Dense(128, activation='tanh', kernel_initializer=initializer),\n",
+    "  tf.keras.layers.Dense(64, activation='tanh', kernel_initializer=initializer),\n",
+    "  tf.keras.layers.Dense(32, activation='tanh', kernel_initializer=initializer),\n",
+    "  tf.keras.layers.Dense(10, activation='softmax')\n",
+    "])\n",
+    "\n",
+    "model.compile(optimizer='adam',\n",
+    "              loss='sparse_categorical_crossentropy',\n",
+    "              metrics=['accuracy'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Training 💪🏻\n",
+    "\n",
+    "The weights and gradients were logged using the helpful `log_gradients` and `log_weights` parameters of `WandbCallback()`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PROJECT = \"tensorflow_initialization_methods\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run = wandb.init(project=PROJECT)\n",
+    "\n",
+    "model.fit(x_train, y_train, epochs=20, callbacks=[WandbCallback(training_data = (x_train, y_train),log_weights = True, log_gradients = True, save_model = False)])\n",
+    "\n",
+    "run.finish()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/colabs/tensorflow/Tensorflow_Initialization_Methods.ipynb
+++ b/colabs/tensorflow/Tensorflow_Initialization_Methods.ipynb
@@ -5,8 +5,7 @@
     "colab": {
       "name": "Tensorflow: Initialization Methods",
       "provenance": [],
-      "authorship_tag": "ABX9TyM3re1IWj4ZNeW2JZowJuDK",
-      "include_colab_link": true
+      "authorship_tag": "ABX9TyM3re1IWj4ZNeW2JZowJuDK"
     },
     "kernelspec": {
       "name": "python3",
@@ -17,16 +16,6 @@
     }
   },
   "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/SauravMaheshkar/Initialization/blob/main/Notebooks/Tensorflow_Initialization_Methods.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
     {
       "cell_type": "markdown",
       "metadata": {
@@ -49,7 +38,7 @@
         "import tensorflow as tf\n",
         "from wandb.keras import WandbCallback"
       ],
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -74,7 +63,7 @@
         "(x_train, y_train),(x_test, y_test) = mnist.load_data()\n",
         "x_train, x_test = x_train / 255.0, x_test / 255.0"
       ],
-      "execution_count": 3,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -113,7 +102,7 @@
         "              loss='sparse_categorical_crossentropy',\n",
         "              metrics=['accuracy'])"
       ],
-      "execution_count": 4,
+      "execution_count": null,
       "outputs": []
     },
     {


### PR DESCRIPTION
Add the colab notebook accompanying the published report titled "[A Gentle Introduction To Weight Initialization for Neural Networks](https://wandb.ai/sauravmaheshkar/initialization/reports/Fundamental-Theory-Weight-Initialization--Vmlldzo2ODExMTg)".

Following the merge (hopefully) I'll change the link in the report to point to the wandb/examples repository instead.