### PR TITLE
fix(integrations): fix tb-pytorch example

### DIFF
--- a/examples/tensorboard/tensorboard-pytorch/train.py
+++ b/examples/tensorboard/tensorboard-pytorch/train.py
@@ -10,14 +10,15 @@ import argparse
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
-import torchvision
-import torchvision.transforms as transforms
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import torch.utils.data
-import wandb
+import torchvision
+import torchvision.transforms as transforms
 from torch.utils.tensorboard import SummaryWriter
+
+import wandb
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--log_dir", type=str, help="Where to store tensorboard files")

--- a/examples/tensorboard/tensorboard-pytorch/train.py
+++ b/examples/tensorboard/tensorboard-pytorch/train.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# https://pytorch.org/tutorials/intermediate/tensorboard_tutorial.html
+# Based on https://pytorch.org/tutorials/intermediate/tensorboard_tutorial.html
 #
 
 # imports
@@ -9,66 +9,75 @@ import argparse
 
 import matplotlib.pyplot as plt
 import numpy as np
-
 import torch
 import torchvision
 import torchvision.transforms as transforms
-
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
-
+import torch.utils.data
+import wandb
+from torch.utils.tensorboard import SummaryWriter
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--log_dir", type=str, help="Where to store tensorboard files")
 args = parser.parse_args()
 
 
-#
-# Added lines for W&B
-#
-import wandb
-wandb.init(sync_tensorboard=True)
-
-
 # transforms
 transform = transforms.Compose(
-    [transforms.ToTensor(),
-    transforms.Normalize((0.5,), (0.5,))])
+    [transforms.ToTensor(), transforms.Normalize((0.5,), (0.5,))]
+)
 
 # datasets
-trainset = torchvision.datasets.FashionMNIST('./data',
-    download=True,
-    train=True,
-    transform=transform)
-testset = torchvision.datasets.FashionMNIST('./data',
-    download=True,
-    train=False,
-    transform=transform)
+trainset = torchvision.datasets.FashionMNIST(
+    "./data", download=True, train=True, transform=transform
+)
+testset = torchvision.datasets.FashionMNIST(
+    "./data", download=True, train=False, transform=transform
+)
 
 # dataloaders
-trainloader = torch.utils.data.DataLoader(trainset, batch_size=4,
-                                        shuffle=True, num_workers=2)
+trainloader = torch.utils.data.DataLoader(
+    trainset, batch_size=4, shuffle=True, num_workers=2
+)
 
 
-testloader = torch.utils.data.DataLoader(testset, batch_size=4,
-                                        shuffle=False, num_workers=2)
+testloader = torch.utils.data.DataLoader(
+    testset, batch_size=4, shuffle=False, num_workers=2
+)
+
+# dataiter = iter(trainloader)
+# images, labels = next(dataiter)
+
+
 
 # constant for classes
-classes = ('T-shirt/top', 'Trouser', 'Pullover', 'Dress', 'Coat',
-        'Sandal', 'Shirt', 'Sneaker', 'Bag', 'Ankle Boot')
+classes = (
+    "T-shirt/top",
+    "Trouser",
+    "Pullover",
+    "Dress",
+    "Coat",
+    "Sandal",
+    "Shirt",
+    "Sneaker",
+    "Bag",
+    "Ankle Boot",
+)
 
 # helper function to show an image
 # (used in the `plot_classes_preds` function below)
 def matplotlib_imshow(img, one_channel=False):
     if one_channel:
         img = img.mean(dim=0)
-    img = img / 2 + 0.5     # unnormalize
+    img = img / 2 + 0.5  # unnormalize
     npimg = img.numpy()
     if one_channel:
         plt.imshow(npimg, cmap="Greys")
     else:
         plt.imshow(np.transpose(npimg, (1, 2, 0)))
+
 
 class Net(nn.Module):
     def __init__(self):
@@ -90,143 +99,152 @@ class Net(nn.Module):
         return x
 
 
-net = Net()
+if __name__ == "__main__":
 
-criterion = nn.CrossEntropyLoss()
-optimizer = optim.SGD(net.parameters(), lr=0.001, momentum=0.9)
+    run = wandb.init(sync_tensorboard=True)
 
-#
-# 1. TensorBoard setup
-#
+    net = Net()
 
-from torch.utils.tensorboard import SummaryWriter
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.SGD(net.parameters(), lr=0.001, momentum=0.9)
 
-# default `log_dir` is "runs" - we'll be more specific here
-log_dir = args.log_dir or 'runs/fashion_mnist_experiment_1'
-writer = SummaryWriter(log_dir)
+    # get some random training images
+    dataiter = iter(trainloader)
+    images, labels = next(dataiter)
 
-#
-# 2. Writing to TensorBoard
-#
+    #
+    # 1. TensorBoard setup
+    #
 
-# get some random training images
-dataiter = iter(trainloader)
-images, labels = next(dataiter)
+    # default `log_dir` is "runs" - we'll be more specific here
+    log_dir = args.log_dir or "runs/fashion_mnist_experiment_1"
+    writer = SummaryWriter(log_dir)
 
-# create grid of images
-img_grid = torchvision.utils.make_grid(images)
+    #
+    # 2. Writing to TensorBoard
+    #
 
-# show images
-matplotlib_imshow(img_grid, one_channel=True)
+    # create grid of images
+    img_grid = torchvision.utils.make_grid(images)
 
-# write to tensorboard
-writer.add_image('four_fashion_mnist_images', img_grid)
+    # show images
+    matplotlib_imshow(img_grid, one_channel=True)
 
-#
-# 3. Inspect the model using TensorBoard
-#
+    # write to tensorboard
+    writer.add_image("four_fashion_mnist_images", img_grid)
 
-writer.add_graph(net, images)
-writer.close()
+    #
+    # 3. Inspect the model using TensorBoard
+    #
 
-#
-# 4. Adding a “Projector” to TensorBoard
-#
+    writer.add_graph(net, images)
+    writer.flush()
 
+    #
+    # 4. Adding a “Projector” to TensorBoard
+    #
 
-# helper function
-def select_n_random(data, labels, n=100):
-    '''
-    Selects n random datapoints and their corresponding labels from a dataset
-    '''
-    assert len(data) == len(labels)
+    # helper function
+    def select_n_random(data, labels, n=100):
+        """
+        Selects n random datapoints and their corresponding labels from a dataset
+        """
+        assert len(data) == len(labels)
 
-    perm = torch.randperm(len(data))
-    return data[perm][:n], labels[perm][:n]
+        perm = torch.randperm(len(data))
+        return data[perm][:n], labels[perm][:n]
 
-# select random images and their target indices
-images, labels = select_n_random(trainset.data, trainset.targets)
+    # select random images and their target indices
+    images, labels = select_n_random(trainset.data, trainset.targets)
 
-# get the class labels for each image
-class_labels = [classes[lab] for lab in labels]
+    # get the class labels for each image
+    class_labels = [classes[lab] for lab in labels]
 
-# log embeddings
-features = images.view(-1, 28 * 28)
-writer.add_embedding(features,
-                    metadata=class_labels,
-                    label_img=images.unsqueeze(1))
-writer.close()
+    # log embeddings
+    features = images.view(-1, 28 * 28)
+    # fixme: this raises the following error in pytorch 1.13.1
+    # AttributeError: module 'tensorflow._api.v2.io.gfile' has no attribute 'get_filesystem'
+    # writer.add_embedding(
+    #     features,
+    #     metadata=class_labels,
+    #     label_img=images.unsqueeze(1),
+    # )
+    writer.flush()
 
-#
-# 5. Tracking model training with TensorBoard
-#
+    #
+    # 5. Tracking model training with TensorBoard
+    #
 
-# helper functions
+    # helper functions
 
-def images_to_probs(net, images):
-    '''
-    Generates predictions and corresponding probabilities from a trained
-    network and a list of images
-    '''
-    output = net(images)
-    # convert output probabilities to predicted class
-    _, preds_tensor = torch.max(output, 1)
-    preds = np.squeeze(preds_tensor.numpy())
-    return preds, [F.softmax(el, dim=0)[i].item() for i, el in zip(preds, output)]
+    def images_to_probs(net, images):
+        """
+        Generates predictions and corresponding probabilities from a trained
+        network and a list of images
+        """
+        output = net(images)
+        # convert output probabilities to predicted class
+        _, preds_tensor = torch.max(output, 1)
+        preds = np.squeeze(preds_tensor.numpy())
+        return preds, [F.softmax(el, dim=0)[i].item() for i, el in zip(preds, output)]
 
+    def plot_classes_preds(net, images, labels):
+        """
+        Generates matplotlib Figure using a trained network, along with images
+        and labels from a batch, that shows the network's top prediction along
+        with its probability, alongside the actual label, coloring this
+        information based on whether the prediction was correct or not.
+        Uses the "images_to_probs" function.
+        """
+        preds, probs = images_to_probs(net, images)
+        # plot the images in the batch, along with predicted and true labels
+        fig = plt.figure(figsize=(12, 48))
+        for idx in np.arange(4):
+            ax = fig.add_subplot(1, 4, idx + 1, xticks=[], yticks=[])
+            matplotlib_imshow(images[idx], one_channel=True)
+            ax.set_title(
+                "{0}, {1:.1%}\n(label: {2})".format(
+                    classes[preds[idx]], probs[idx], classes[labels[idx]]
+                ),
+                color=("green" if preds[idx] == labels[idx].item() else "red"),
+            )
+        return fig
 
-def plot_classes_preds(net, images, labels):
-    '''
-    Generates matplotlib Figure using a trained network, along with images
-    and labels from a batch, that shows the network's top prediction along
-    with its probability, alongside the actual label, coloring this
-    information based on whether the prediction was correct or not.
-    Uses the "images_to_probs" function.
-    '''
-    preds, probs = images_to_probs(net, images)
-    # plot the images in the batch, along with predicted and true labels
-    fig = plt.figure(figsize=(12, 48))
-    for idx in np.arange(4):
-        ax = fig.add_subplot(1, 4, idx+1, xticks=[], yticks=[])
-        matplotlib_imshow(images[idx], one_channel=True)
-        ax.set_title("{0}, {1:.1%}\n(label: {2})".format(
-            classes[preds[idx]],
-            probs[idx],
-            classes[labels[idx]]),
-                    color=("green" if preds[idx]==labels[idx].item() else "red"))
-    return fig
-running_loss = 0.0
-for epoch in range(1):  # loop over the dataset multiple times
+    running_loss = 0.0
+    for epoch in range(1):  # loop over the dataset multiple times
 
-    for i, data in enumerate(trainloader, 0):
+        for i, data in enumerate(trainloader, 0):
 
-        # get the inputs; data is a list of [inputs, labels]
-        inputs, labels = data
+            # get the inputs; data is a list of [inputs, labels]
+            inputs, labels = data
 
-        # zero the parameter gradients
-        optimizer.zero_grad()
+            # zero the parameter gradients
+            optimizer.zero_grad()
 
-        # forward + backward + optimize
-        outputs = net(inputs)
-        loss = criterion(outputs, labels)
-        loss.backward()
-        optimizer.step()
+            # forward + backward + optimize
+            outputs = net(inputs)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
 
-        running_loss += loss.item()
-        if i % 1000 == 999:    # every 1000 mini-batches...
+            running_loss += loss.item()
+            if i % 1000 == 999:  # every 1000 mini-batches...
 
-            # ...log the running loss
-            writer.add_scalar('training loss',
-                            running_loss / 1000,
-                            epoch * len(trainloader) + i)
+                # ...log the running loss
+                writer.add_scalar(
+                    "training loss", running_loss / 1000, epoch * len(trainloader) + i
+                )
 
-            # ...log a Matplotlib Figure showing the model's predictions on a
-            # random mini-batch
-            writer.add_figure('predictions vs. actuals',
-                            plot_classes_preds(net, inputs, labels),
-                            global_step=epoch * len(trainloader) + i)
-            running_loss = 0.0
-# Note: if you don't call this and logdir is an s3 url, the
-# last file will never get correctly written.
-writer.close()
-print('Finished Training')
+                # ...log a Matplotlib Figure showing the model's predictions on a
+                # random mini-batch
+                writer.add_figure(
+                    "predictions vs. actuals",
+                    plot_classes_preds(net, inputs, labels),
+                    global_step=epoch * len(trainloader) + i,
+                )
+                running_loss = 0.0
+    # Note: if you don't call this and logdir is an s3 url, the
+    # last file will never get correctly written.
+    writer.close()
+    run.finish()
+    print("Finished Training")


### PR DESCRIPTION
The `wandb-examples-tensorboard-pytorch:init:py37` has been broken, which was likely caused by a DataLoader refactor on the pytorch side -- how it does data loading parallelization with multiprocessing and how that interacts with how and when we spin things up.

Tried running the script, works fine: https://wandb.ai/dimaduev/examples-examples_tensorboard_tensorboard-pytorch/runs/zg417bh4?workspace=user-dimaduev