### PR TITLE
Fix broken product icons at the top of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,50 +10,50 @@ Use W&B to build better models faster. Track and visualize all the pieces of you
 <p align='center'>
 <a target="_blank" href="https://docs.wandb.ai/guides/track?utm_source=github&utm_medium=code&utm_campaign=wandb&utm_content=readme">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_dark_background/experiments_icon.svg" width="13.5%">
-  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_light/experiments_icon.svg" width="13.5%">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_dark_background/experiments-dark.svg" width="13.5%">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_light/experiments-light.svg" width="13.5%">
   <img alt="Weights and Biases Experiments" src="">
 </picture>
 </a>
 <a target="_blank" href="https://docs.wandb.ai/guides/reports?utm_source=github&utm_medium=code&utm_campaign=wandb&utm_content=readme">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_dark_background/reports_icon.svg" width="13.5%">
-  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_light/reports_icon.svg" width="13.5%">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_dark_background/report-dark.svg" width="13.5%">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_light/report-light.svg" width="13.5%">
   <img alt="Weights and Biases Reports" src="">
 </picture>
 </a>
 <a target="_blank" href="https://docs.wandb.ai/guides/artifacts?utm_source=github&utm_medium=code&utm_campaign=wandb&utm_content=readme">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_dark_background/artifacts_icon.svg" width="13.5%">
-  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_light/artifacts_icon.svg" width="13.5%">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_dark_background/artifacts-dark.svg" width="13.5%">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_light/artifacts-light.svg" width="13.5%">
   <img alt="Weights and Biases Artifacts" src="">
 </picture>
 </a>
 <a target="_blank" href="https://docs.wandb.ai/guides/data-vis?utm_source=github&utm_medium=code&utm_campaign=wandb&utm_content=readme">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_dark_background/tables_icon.svg" width="13.5%">
-  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_light/tables_icon.svg" width="13.5%">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_dark_background/tables-dark.svg" width="13.5%">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_light/tables-light.svg" width="13.5%">
   <img alt="Weights and Biases Tables" src="">
 </picture>
 </a>
 <a target="_blank" href="https://docs.wandb.ai/guides/sweeps?utm_source=github&utm_medium=code&utm_campaign=wandb&utm_content=readme">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_dark_background/sweeps_icon.svg" width="13.5%">
-  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_light/sweeps_icon.svg" width="13.5%">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_dark_background/sweeps-dark.svg" width="13.5%">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_light/sweeps-light.svg" width="13.5%">
   <img alt="Weights and Biases Sweeps" src="">
 </picture>
 </a>
 <a target="_blank" href="https://docs.wandb.ai/guides/models?utm_source=github&utm_medium=code&utm_campaign=wandb&utm_content=readme">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_dark_background/models_icon.svg" width="13.5%">
-  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_light/models_icon.svg" width="13.5%">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_dark_background/models-dark.svg" width="13.5%">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_light/models-light.svg" width="13.5%">
   <img alt="Weights and Biases Model Management" src="">
 </picture>
 </a>
 <a target="_blank" href="https://docs.wandb.ai/guides/launch?utm_source=github&utm_medium=code&utm_campaign=wandb&utm_content=readme">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_dark_background/launch_icon.svg" width="13.5%">
-  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_light/launch_icon.svg" width="13.5%">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_dark_background/launch-dark.svg" width="13.5%">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/wandb/wandb/main/docs/README_images/Product_Icons_light/launch-light.svg" width="13.5%">
   <img alt="Weights and Biases Launch" src="">
 </picture>
 </a>


### PR DESCRIPTION
Slack thread for this problem https://weightsandbiases.slack.com/archives/C01DX8LRZEJ/p1683124364177449


## Bug report from Scott Condron:
I wasn't sure where to post this, but it seems like the images on the examples repo have disappeared https://github.com/wandb/examples

![image](https://user-images.githubusercontent.com/6355078/235984338-303f487a-0027-4ac9-9e3d-c0f0e4d72d30.png)



