### PR TITLE
Bump LangChain version to 0.0.168

### DIFF
--- a/colabs/prompts/W&B_Prompts_Quickstart.ipynb
+++ b/colabs/prompts/W&B_Prompts_Quickstart.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -38,17 +39,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "!pip install \"wandb>=0.15.2\" -qqq\n",
-    "!pip install \"langchain==v0.0.169\" openai"
+    "!pip install \"langchain==v0.0.168\" openai"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "import langchain\n",
@@ -68,7 +77,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -126,7 +139,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "from wandb.integration.langchain import WandbTracer\n",
@@ -145,7 +162,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "from langchain.agents import load_tools\n",
@@ -157,7 +178,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "llm = OpenAI(temperature=0)\n",
@@ -176,7 +201,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "questions = [\n",
@@ -205,7 +234,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "WandbTracer.finish()"
@@ -240,7 +273,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "from wandb.sdk.data_types import trace_tree\n",
@@ -258,7 +295,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "parent_span = trace_tree.Span(name=\"Example Span\", span_kind = trace_tree.SpanKind.AGENT)"
@@ -275,7 +316,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "# Create a span for a call to a Tool\n",
@@ -300,7 +345,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "tool_span.add_named_result({\"input\": \"search: google founded in year\"}, {\"response\": \"1998\"})\n",
@@ -326,7 +375,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "run = wandb.init(name=\"manual_span_demo\", project=\"wandb_prompts_demo\")\n",
@@ -345,7 +398,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": []
   }


### PR DESCRIPTION
Breaking changes from 0.0.169 and beyond mean that we need LangChain 0.0.168 and wandb 0.15.2