### PR TITLE
Remove beta log_model use_model API

### DIFF
--- a/colabs/wandb-artifacts/Model_Management_Guide.ipynb
+++ b/colabs/wandb-artifacts/Model_Management_Guide.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -9,7 +8,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -27,7 +25,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -38,11 +35,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!pip install wandb -U -qqq"
@@ -51,11 +44,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "project_name = \"model-registry\" #@param {type:\"string\"}\n",
@@ -179,7 +168,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -189,11 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import wandb\n",
@@ -278,7 +262,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -288,11 +271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import wandb\n",

--- a/colabs/wandb-artifacts/Model_Management_Guide.ipynb
+++ b/colabs/wandb-artifacts/Model_Management_Guide.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -8,6 +9,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -25,6 +27,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -35,7 +38,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "!pip install wandb -U -qqq"
@@ -44,14 +51,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "project_name = \"model-registry\" #@param {type:\"string\"}\n",
     "# dataset_name = \"mnist\" #@param {type:\"string\"}\n",
     "dataset_name = \"mnist\"\n",
     "model_collection_name = \"MNIST Grayscale 28x28\" #@param {type:\"string\"}\n",
-    "use_beta_apis = False #@param {type:\"boolean\"}\n",
     "\n",
     "import torch\n",
     "from torchvision import datasets, transforms\n",
@@ -169,6 +179,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -178,12 +189,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "import wandb\n",
-    "from wandb.beta.workflows import log_model, link_model\n",
-    "\n",
     "import torch\n",
     "import cloudpickle\n",
     "\n",
@@ -237,17 +250,12 @@
     "    best_loss = val_loss\n",
     "\n",
     "  ##### W&B MODEL MANAGEMENT SPECIFIC CALLS ######\n",
-    "  if use_beta_apis:\n",
-    "    model_version = log_model(model, \"mnist\", [\"best\"] if is_best else None)\n",
-    "    if is_best:\n",
-    "      best_model = model_version\n",
-    "  else:\n",
-    "    art = wandb.Artifact(f\"mnist-{wandb.run.id}\", \"model\")\n",
-    "    torch.save(model, \"model.pt\", pickle_module=cloudpickle)\n",
-    "    art.add_file(\"model.pt\")\n",
-    "    wandb.log_artifact(art, aliases=[\"best\", \"latest\"] if is_best else None)\n",
-    "    if is_best:\n",
-    "      best_model = art\n",
+    "  art = wandb.Artifact(f\"mnist-{wandb.run.id}\", \"model\")\n",
+    "  torch.save(model, \"model.pt\", pickle_module=cloudpickle)\n",
+    "  art.add_file(\"model.pt\")\n",
+    "  wandb.log_artifact(art, aliases=[\"best\", \"latest\"] if is_best else None)\n",
+    "  if is_best:\n",
+    "    best_model = art\n",
     "  wandb.log({\n",
     "      \"epoch_ndx\": epoch_ndx,\n",
     "      \"val_loss\": val_loss,\n",
@@ -263,16 +271,14 @@
     "train_model(model, optimizer, scheduler, train, val, epochs, on_batch_end, on_epoch_end)\n",
     "\n",
     "##### W&B MODEL MANAGEMENT SPECIFIC CALLS ######\n",
-    "if use_beta_apis:\n",
-    "  link_model(best_model, model_collection_name)\n",
-    "else:\n",
-    "  wandb.run.link_artifact(best_model, model_collection_name, [\"latest\"])\n",
+    "wandb.run.link_artifact(best_model, model_collection_name, [\"latest\"])\n",
     "\n",
     "# Finish the Run\n",
     "wandb.finish()"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -282,13 +288,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "import wandb\n",
-    "from wandb.beta.workflows import use_model\n",
-    "\n",
     "import torch\n",
+    "\n",
     "# Startup a W&B Run\n",
     "wandb.init(project=project_name, \n",
     "  job_type=\"model_evaluator\",\n",
@@ -308,13 +317,9 @@
     "wandb.use_artifact(art)\n",
     "\n",
     "##### W&B MODEL MANAGEMENT SPECIFIC CALLS ######\n",
-    "if use_beta_apis:\n",
-    "  model_art = use_model(f\"{model_collection_name}:latest\")\n",
-    "  model_obj = model_art.model_obj()\n",
-    "else:\n",
-    "  model_art = wandb.use_artifact(f\"{model_collection_name}:latest\")\n",
-    "  model_path = model_art.get_path(\"model.pt\").download()\n",
-    "  model_obj = torch.load(model_path)\n",
+    "model_art = wandb.use_artifact(f\"{model_collection_name}:latest\")\n",
+    "model_path = model_art.get_path(\"model.pt\").download()\n",
+    "model_obj = torch.load(model_path)\n",
     "\n",
     "model_obj.eval()\n",
     "val_loss, val_acc, preds = evaluate_model(model_obj, test)\n",
@@ -331,21 +336,10 @@
     "})\n",
     "\n",
     "##### W&B MODEL MANAGEMENT SPECIFIC CALLS ######\n",
-    "if use_beta_apis:\n",
-    "  link_model(model_art, model_collection_name, aliases=[\"production\"])\n",
-    "else:\n",
-    "  wandb.run.link_artifact(model_art, model_collection_name, [\"latest\", \"production\"])\n",
-    "\n",
+    "wandb.run.link_artifact(model_art, model_collection_name, [\"latest\", \"production\"])\n",
     "\n",
     "wandb.finish()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
- **Problem**: Beta apis for `log_model()` and `use_model()` aren't ready to suggest to users. We're planning to take the API another direction soon.
- **Context**: [Slack thread](https://weightsandbiases.slack.com/archives/CT4901KC5/p1685564138468699)
- **Solution**: Remove these beta APIs from the colab to avoid confusing users.