### PR TITLE
fix: update prompts quickstart with new langchain tracer

### DIFF
--- a/colabs/prompts/W&B_Prompts_Quickstart.ipynb
+++ b/colabs/prompts/W&B_Prompts_Quickstart.ipynb
@@ -73,17 +73,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "OpenAI API key configured\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "from getpass import getpass\n",
@@ -139,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,32 +181,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Failed to detect the name of this notebook, you can set it manually with the WANDB_NOTEBOOK_NAME environment variable to enable code saving.\n",
-      "\u001b[34m\u001b[1mwandb\u001b[0m: Streaming LangChain activity to W&B at https://wandb.ai/parambharat/wandb_prompts_quickstart/runs/wbq85rbb\n",
-      "\u001b[34m\u001b[1mwandb\u001b[0m: `WandbTracer` is currently in beta.\n",
-      "\u001b[34m\u001b[1mwandb\u001b[0m: Please report any issues to https://github.com/wandb/wandb/issues with the tag `langchain`.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2.323\n",
-      "0.005720801417544866\n",
-      "0.43737990984599\n",
-      "LLMMathChain._evaluate(\"\n",
-      "1/0\n",
-      "\") raised error: division by zero. Please try again with a valid numerical expression\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "tracer = WandbTracer(wandb_config)\n",
     "questions = [\n",
@@ -242,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/colabs/prompts/W&B_Prompts_Quickstart.ipynb
+++ b/colabs/prompts/W&B_Prompts_Quickstart.ipynb
@@ -41,29 +41,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!pip install \"wandb>=0.15.3\" -qqq\n",
-    "!pip install \"langchain>=0.0.172\" openai"
+    "!pip install \"langchain>=0.0.188\" openai"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import langchain\n",
-    "assert langchain.__version__ >= \"0.0.172\", \"Please ensure you are using LangChain v0.0.172 or higher\"\n",
+    "assert langchain.__version__ >= \"0.0.188\", \"Please ensure you are using LangChain v0.0.188 or higher\"\n",
     "\n",
     "import wandb \n",
     "assert wandb.__version__ >= \"0.15.3\", \"Please ensure you are using wandb v0.15.3 or higher\""
@@ -81,13 +73,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OpenAI API key configured\n"
+     ]
     }
-   },
-   "outputs": [],
+   ],
    "source": [
     "import os\n",
     "from getpass import getpass\n",
@@ -143,15 +139,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "execution_count": 2,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "from wandb.integration.langchain import WandbTracer\n",
+    "from langchain.callbacks.tracers import WandbTracer\n",
     "\n",
     "wandb_config = {\"project\": \"wandb_prompts_quickstart\"}"
    ]
@@ -166,12 +158,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "execution_count": 3,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from langchain.agents import load_tools\n",
@@ -182,12 +170,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "execution_count": 4,
+   "metadata": {},
    "outputs": [],
    "source": [
     "llm = OpenAI(temperature=0)\n",
@@ -200,19 +184,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Pass `WandbTracer` when you call your LangChain chain or agent to log your trace to W&B"
+    "Pass and instance of the `WandbTracer` as a callback when you call your LangChain chain or agent to log your trace to W&B"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Failed to detect the name of this notebook, you can set it manually with the WANDB_NOTEBOOK_NAME environment variable to enable code saving.\n",
+      "\u001b[34m\u001b[1mwandb\u001b[0m: Streaming LangChain activity to W&B at https://wandb.ai/parambharat/wandb_prompts_quickstart/runs/wbq85rbb\n",
+      "\u001b[34m\u001b[1mwandb\u001b[0m: `WandbTracer` is currently in beta.\n",
+      "\u001b[34m\u001b[1mwandb\u001b[0m: Please report any issues to https://github.com/wandb/wandb/issues with the tag `langchain`.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2.323\n",
+      "0.005720801417544866\n",
+      "0.43737990984599\n",
+      "LLMMathChain._evaluate(\"\n",
+      "1/0\n",
+      "\") raised error: division by zero. Please try again with a valid numerical expression\n"
+     ]
     }
-   },
-   "outputs": [],
+   ],
    "source": [
+    "tracer = WandbTracer(wandb_config)\n",
     "questions = [\n",
     "    \"Find the square root of 5.4.\",\n",
     "    \"What is 3 divided by 7.34 raised to the power of pi?\",\n",
@@ -221,7 +225,7 @@
     "]\n",
     "for question in questions:\n",
     "  try:\n",
-    "    answer = agent.run(question, callbacks=[WandbTracer(wandb_config)])\n",
+    "    answer = agent.run(question, callbacks=[tracer])\n",
     "    print(answer)\n",
     "  except Exception as e:\n",
     "    print(e)\n",
@@ -233,20 +237,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When you're finished your session, it is best practice to call `WandbTracer.finish()` to ensure your wandb run closes cleanly."
+    "When you're finished your session, it is best practice to call `tracer.finish()` or `wandb.finish()` to ensure your wandb run closes cleanly."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "WandbTracer.finish()"
+    "tracer.finish()"
    ]
   },
   {
@@ -278,11 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from wandb.sdk.data_types import trace_tree\n",
@@ -300,11 +296,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "parent_span = trace_tree.Span(name=\"Example Span\", span_kind = trace_tree.SpanKind.AGENT)"
@@ -321,11 +313,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create a span for a call to a Tool\n",
@@ -350,11 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tool_span.add_named_result({\"input\": \"search: google founded in year\"}, {\"response\": \"1998\"})\n",
@@ -380,11 +364,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "run = wandb.init(name=\"manual_span_demo\", project=\"wandb_prompts_demo\")\n",
@@ -403,11 +383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -422,6 +398,18 @@
   "kernelspec": {
    "display_name": "Python 3",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,

--- a/colabs/prompts/WandB_Prompts_Quickstart.ipynb
+++ b/colabs/prompts/WandB_Prompts_Quickstart.ipynb
@@ -1,11 +1,10 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/wandb/examples/blob/master/colabs/prompts/W&B_Prompts_Quickstart.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/wandb/examples/blob/master/colabs/prompts/WandB_Prompts_Quickstart.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "<!--- @wandbcode{prompts-quickstart} -->"
    ]
   },
@@ -367,18 +366,6 @@
   "kernelspec": {
    "display_name": "Python 3",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR updates the prompts quick start example with imports from the updated langchain version 