### PR TITLE
chore(sweeps): update job paths

### DIFF
--- a/examples/launch/launch-sweeps/custom-scheduler/custom_job_sweep_config.yaml
+++ b/examples/launch/launch-sweeps/custom-scheduler/custom_job_sweep_config.yaml
@@ -6,7 +6,7 @@ scheduler:
     method: grid
 
 # the training job to run
-job: 'wandb/jobs/Example Train Job:latest'
+job: wandb/sweep-jobs/job-fashion-MNIST-train:latest
 
 parameters:
   param1:

--- a/examples/launch/launch-sweeps/optuna-scheduler/README.md
+++ b/examples/launch/launch-sweeps/optuna-scheduler/README.md
@@ -6,7 +6,7 @@ Note: This example assumes familiarity with launch setup and creating jobs. Info
 
 [Optuna](https://optuna.org/) is an open-source hyperparameter tuning [library](https://optuna.readthedocs.io/en/stable/) that exposes significant flexibility to sampling, pruning, and parameter space creation.  
 
-Using sweeps on launch, many of these features can be used to schedule wandb sweeps. To do so, use the `'wandb/jobs/Optuna Scheduler Image Job:latest'` job, or create your own using the `optuna_scheduler.py` file found in the `wandb/launch-jobs` repo [here](https://github.com/wandb/launch-jobs/jobs/sweep_schedulers/optuna_scheduler.py).
+Using sweeps on launch, many of these features can be used to schedule wandb sweeps. To do so, use the `wandb/sweep-jobs/job-optuna-sweep-scheduler:latest` job, or create your own using the `optuna_scheduler.py` file found in the `wandb/launch-jobs` repo [here](https://github.com/wandb/launch-jobs/jobs/sweep_schedulers/optuna_scheduler.py).
 
 
 ### Run a basic example:
@@ -24,14 +24,15 @@ The `optuna_config_basic.yaml` file configures a basic sweep using an Optuna [Pe
 ```yaml
 # optuna_config_basic.yaml
 description: A basic configuration for an Optuna scheduler
-job: 'wandb/jobs/Example Train Job:latest'
+# a basic training job to run
+job: wandb/sweep-jobs/job-fashion-MNIST-train:latest
 run_cap: 5
 metric:
   name: val_acc
   goal: maximize
 
 scheduler:
-  job: 'wandb/jobs/Optuna Scheduler Image Job:latest'
+  job: wandb/sweep-jobs/job-optuna-sweep-scheduler:latest
   resource: local-container  # required for scheduler jobs sourced from images
   num_workers: 2  # number of concurrent runs
   settings:
@@ -53,7 +54,7 @@ parameters:
 
 1. Samplers
 
-There are a variety of samplers that can be used to pick hyperparameters from a given search space, found [here](https://optuna.readthedocs.io/en/stable/reference/samplers/index.html). They can be configured to work with the `wandb/jobs/job-OptunaScheduler` job by defining specific settings in the sweep config. 
+There are a variety of samplers that can be used to pick hyperparameters from a given search space, found [here](https://optuna.readthedocs.io/en/stable/reference/samplers/index.html). They can be configured to work with the `wandb/sweep-jobs/job-optuna-sweep-scheduler:latest` job by defining specific settings in the sweep config. 
 
 For example: 
 

--- a/examples/launch/launch-sweeps/optuna-scheduler/README.md
+++ b/examples/launch/launch-sweeps/optuna-scheduler/README.md
@@ -28,8 +28,8 @@ description: A basic configuration for an Optuna scheduler
 job: wandb/sweep-jobs/job-fashion-MNIST-train:latest
 run_cap: 5
 metric:
-  name: val_acc
-  goal: maximize
+  name: epoch/val_loss
+  goal: minimize
 
 scheduler:
   job: wandb/sweep-jobs/job-optuna-sweep-scheduler:latest

--- a/examples/launch/launch-sweeps/optuna-scheduler/optuna_config_advanced.yaml
+++ b/examples/launch/launch-sweeps/optuna-scheduler/optuna_config_advanced.yaml
@@ -1,12 +1,12 @@
 # optuna_config_artifact.yaml
 description: Load parameter space from a pythonic search space file
 # training job to run
-job: 'wandb/sweep-jobs/job-fashion-MNIST-train:latest'
+job: wandb/sweep-jobs/job-fashion-MNIST-train:latest
 run_cap: 5
 
 metric:
-  name: # <METRIC>
-  goal: # maximize, minimize
+  name: epoch/val_loss
+  goal: minimize
 
 scheduler:
   job: wandb/sweep-jobs/job-optuna-sweep-scheduler:latest

--- a/examples/launch/launch-sweeps/optuna-scheduler/optuna_config_advanced.yaml
+++ b/examples/launch/launch-sweeps/optuna-scheduler/optuna_config_advanced.yaml
@@ -1,6 +1,7 @@
 # optuna_config_artifact.yaml
 description: Load parameter space from a pythonic search space file
-job: # training job
+# training job to run
+job: 'wandb/sweep-jobs/job-fashion-MNIST-train:latest'
 run_cap: 5
 
 metric:
@@ -8,8 +9,7 @@ metric:
   goal: # maximize, minimize
 
 scheduler:
-  # TODO(gst): replace with public wandb jobo
-  job: griffin_wb/public/job-wandb_job_sweep_scheduler_optuna:latest
+  job: wandb/sweep-jobs/job-optuna-sweep-scheduler:latest
   num_workers: 2
   settings:
     optuna_source: examples/launch/launch-sweeps/optuna-scheduler/optuna_wandb.py

--- a/examples/launch/launch-sweeps/optuna-scheduler/optuna_config_advanced.yaml
+++ b/examples/launch/launch-sweeps/optuna-scheduler/optuna_config_advanced.yaml
@@ -3,7 +3,6 @@ description: Load parameter space from a pythonic search space file
 # training job to run
 job: wandb/sweep-jobs/job-fashion-MNIST-train:latest
 run_cap: 5
-
 metric:
   name: epoch/val_loss
   goal: minimize

--- a/examples/launch/launch-sweeps/optuna-scheduler/optuna_config_basic.yaml
+++ b/examples/launch/launch-sweeps/optuna-scheduler/optuna_config_basic.yaml
@@ -1,13 +1,14 @@
 # optuna_config_basic.yaml
 description: A basic configuration for an Optuna scheduler
-job: 'wandb/jobs/Example Train Job:latest'
+# training job to run
+job: wandb/sweep-jobs/job-fashion-MNIST-train:latest
 run_cap: 5
 metric:
   name: val_acc
   goal: maximize
 
 scheduler:
-  job: 'wandb/jobs/Optuna Scheduler Image Job:latest'
+  job: wandb/sweep-jobs/job-optuna-sweep-scheduler:latest
   resource: local-container  # required for scheduler jobs sourced from images
   num_workers: 2
   settings:

--- a/examples/launch/launch-sweeps/optuna-scheduler/optuna_config_basic.yaml
+++ b/examples/launch/launch-sweeps/optuna-scheduler/optuna_config_basic.yaml
@@ -4,8 +4,8 @@ description: A basic configuration for an Optuna scheduler
 job: wandb/sweep-jobs/job-fashion-MNIST-train:latest
 run_cap: 5
 metric:
-  name: val_acc
-  goal: maximize
+  name: epoch/val_loss
+  goal: minimize
 
 scheduler:
   job: wandb/sweep-jobs/job-optuna-sweep-scheduler:latest
@@ -19,6 +19,6 @@ scheduler:
         n_warmup_steps: 10  # pruning disabled for first x steps
 
 parameters:
-  param1:
-    min: 0
-    max: 10
+  learning_rate:
+    min: 0.0001
+    max: 1.0

--- a/examples/launch/launch-sweeps/quickstart/README.md
+++ b/examples/launch/launch-sweeps/quickstart/README.md
@@ -25,6 +25,9 @@ run_cap: 50
 
 # a basic MNIST training job
 job: wandb/sweep-jobs/job-fashion-MNIST-train:latest
+metric:
+  name: epoch/val_loss
+  goal: minimize
 
 # some parameters to tune
 parameters:

--- a/examples/launch/launch-sweeps/quickstart/README.md
+++ b/examples/launch/launch-sweeps/quickstart/README.md
@@ -23,8 +23,8 @@ description: sweeps on launch quickstart
 method: grid
 run_cap: 50
 
-# the training job
-job: 'wandb/jobs/Example Train Job:latest'
+# a basic MNIST training job
+job: wandb/sweep-jobs/job-fashion-MNIST-train:latest
 
 # some parameters to tune
 parameters:

--- a/examples/launch/launch-sweeps/quickstart/launch_sweep_config.yaml
+++ b/examples/launch/launch-sweeps/quickstart/launch_sweep_config.yaml
@@ -4,7 +4,7 @@ method: grid
 run_cap: 10
 
 # the training job
-job: 'wandb/jobs/Example Train Job:latest'
+job: wandb/sweep-jobs/job-fashion-MNIST-train:latest
 
 # some parameters to tune
 parameters:

--- a/examples/launch/launch-sweeps/quickstart/launch_sweep_config.yaml
+++ b/examples/launch/launch-sweeps/quickstart/launch_sweep_config.yaml
@@ -15,7 +15,7 @@ parameters:
     values: [0, 0.0001, 0.001, 0.01, 0.1, 1]
   epochs:
     max: 20
-    min: 0
+    min: 10
     distribution: int_uniform
 
 # Optional Scheduler Params:

--- a/examples/launch/launch-sweeps/quickstart/launch_sweep_config.yaml
+++ b/examples/launch/launch-sweeps/quickstart/launch_sweep_config.yaml
@@ -5,6 +5,9 @@ run_cap: 10
 
 # the training job
 job: wandb/sweep-jobs/job-fashion-MNIST-train:latest
+metric:
+  name: epoch/val_loss
+  goal: minimize
 
 # some parameters to tune
 parameters:


### PR DESCRIPTION
We decided to go a different route by making public jobs in the `wandb/sweep-jobs` project, updating the public docs to reflect that.