### PR TITLE
Correct link to Create a new Registered Model

### DIFF
--- a/colabs/wandb-artifacts/Model_Management_Guide.ipynb
+++ b/colabs/wandb-artifacts/Model_Management_Guide.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "source": [
     "# Setup\n",
-    "**Stop! 🛑** Please complete [Step 1 of the tutorial](https://docs.wandb.ai/guides/models#1.-create-a-new-model-collection) before continuing. This will ensure you have a **Model Collection** defined in your project. Enter the Project name where you created the Collection in `project_name` and the name of the Collection in the `model_collection_name` fields respectively."
+    "**Stop! 🛑** Please complete [Step 1 of the tutorial](https://docs.wandb.ai/guides/models/walkthrough#1-create-a-new-registered-model) before continuing. This will ensure you have a **Model Collection** defined in your project. Enter the Project name where you created the Collection in `project_name` and the name of the Collection in the `model_collection_name` fields respectively."
    ]
   },
   {


### PR DESCRIPTION
Currently link to teach someone how to create a registered model redirects to main model page - https://docs.wandb.ai/guides/models. 

It should be to: https://docs.wandb.ai/guides/models/walkthrough#1-create-a-new-registered-model