### PR TITLE
Update prompts example to use sdk for tracer

### DIFF
--- a/colabs/prompts/WandB_Prompts_Quickstart.ipynb
+++ b/colabs/prompts/WandB_Prompts_Quickstart.ipynb
@@ -51,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"wandb>=0.15.4\" -qqq\n",
+    "!pip install \"wandb>=0.15.6\" -qqq\n",
     "!pip install \"langchain>=0.0.218\" openai -qqq"
    ]
   },
@@ -62,7 +62,7 @@
    "outputs": [],
    "source": [
     "import langchain\n",
-    "assert langchain.__version__ >= \"0.0.218\", \"Please ensure you are using LangChain v0.0.188 or higher\""
+    "assert langchain.__version__ >= \"0.0.218\", \"Please ensure you are using LangChain v0.0.218 or higher\""
    ]
   },
   {
@@ -257,19 +257,7 @@
     "\n",
     "In this quickstart, we will how to log a single call to an OpenAI model to W&B Trace as a single span. Then we will show how to log a more complex series of nested spans.\n",
     "\n",
-    "## Logging with W&B Trace\n",
-    "A high-level Trace api is available from the [`wandb-addon`](https://github.com/soumik12345/wandb-addons) community library from [@soumik12345](https://github.com/soumik12345). This will be replaced by a wandb-native integration shortly."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Install wandb-addons\n",
-    "!git clone https://github.com/soumik12345/wandb-addons.git\n",
-    "!pip install ./wandb-addons[prompts] openai wandb -qqq "
+    "## Logging with W&B Trace"
    ]
   },
   {
@@ -459,7 +447,7 @@
     "      outputs={\"response\": response_text})\n",
     "\n",
     "# update the Chain span's end time\n",
-    "chain_span._span.end_time_ms = llm_end_time_ms\n",
+    "chain_span.end_time_ms = llm_end_time_ms\n",
     "\n",
     "\n",
     "# part 4 - the Agent then calls a Tool...\n",
@@ -484,7 +472,7 @@
     "# part 5 - the final results from the tool are added \n",
     "root_span.add_inputs_and_outputs(inputs={\"query\": query},\n",
     "                                 outputs={\"result\": days_to_election})\n",
-    "root_span._span.end_time_ms = tool_end_time_ms\n",
+    "root_span.end_time_ms = tool_end_time_ms\n",
     "\n",
     "\n",
     "# part 6 - log all spans to W&B by logging the root span\n",


### PR DESCRIPTION
Updates the Prompts example to use wandb instead of wandb-addons now that Tracer is in the SDK