### PR TITLE
fix(notebooks): correct syntax errors and chart field assignment

### DIFF
--- a/colabs/intro/Report_API_Quickstart.ipynb
+++ b/colabs/intro/Report_API_Quickstart.ipynb
@@ -38,11 +38,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install wandb"
+    "!pip install wandb -qqq"
    ]
   },
   {
@@ -521,7 +521,7 @@
    "source": [
     "report = wr.Report(\n",
     "    PROJECT,\n",
-    "    title=\"Resizing panels\"\n",
+    "    title=\"Resizing panels\",\n",
     "    description=\"Look at this wide parallel coordinates plot!\",\n",
     "    blocks=[\n",
     "        wr.PanelGrid(\n",
@@ -563,7 +563,7 @@
     "report = wr.Report(\n",
     "    PROJECT,\n",
     "    title='W&B Block Gallery',\n",
-    "    description=\"Check out all of the blocks available in W&B\"\n",
+    "    description=\"Check out all of the blocks available in W&B\",\n",
     "    blocks=[\n",
     "        wr.H1(text=\"Heading 1\"),\n",
     "        wr.P(text=\"Normal paragraph\"),\n",
@@ -621,7 +621,7 @@
     "report = wr.Report(\n",
     "    project=PROJECT,\n",
     "    title='W&B Panel Gallery',\n",
-    "    description=\"Check out all of the panels available in W&B\"\n",
+    "    description=\"Check out all of the panels available in W&B\",\n",
     "    width='fluid',\n",
     "    blocks=[\n",
     "        wr.PanelGrid(\n",
@@ -703,7 +703,7 @@
     "                wr.CustomChart(\n",
     "                    query={'summary': ['val_loss', 'val_acc']},\n",
     "                    chart_name='wandb/scatter/v0',\n",
-    "                    user_fields={'x': 'val_loss', 'y': 'val_acc'}\n",
+    "                    chart_fields={'x': 'val_loss', 'y': 'val_acc'}\n",
     "                ),\n",
     "                wr.WeavePanelSummaryTable(\"my-table\"),\n",
     "                wr.WeavePanelArtifact('model-1', 'lineage', layout={'w': 24, 'h': 12}),\n",
@@ -812,7 +812,7 @@
    "source": [
     "report = wr.Report(PROJECT,\n",
     "    title=\"Report with links\",\n",
-    "    description=\"Use `wr.Link(text, url)` to add links inside normal text, or use normal markdown syntax in a MarkdownBlock\"\n",
+    "    description=\"Use `wr.Link(text, url)` to add links inside normal text, or use normal markdown syntax in a MarkdownBlock\",\n",
     "    blocks=[\n",
     "        wr.H1(\"This is a normal heading\"),\n",
     "        wr.P(\"And here is some normal text\"),\n",
@@ -835,7 +835,7 @@
     "report3 = wr.Report(\n",
     "    PROJECT,\n",
     "    title=\"Combined blocks report\",\n",
-    "    description=\"This report combines blocks from both Report 1 and Report 2\"\n",
+    "    description=\"This report combines blocks from both Report 1 and Report 2\",\n",
     "    blocks=[*report1.blocks, *report2.blocks]\n",
     ")\n",
     "report3.save()"
@@ -857,7 +857,7 @@
     "report4 = wr.Report(\n",
     "    PROJECT,\n",
     "    title=\"Referenced reports via Gallery\",\n",
-    "    description=\"This report has gallery links to Report1 and Report 2\"\n",
+    "    description=\"This report has gallery links to Report1 and Report 2\",\n",
     "    blocks=[wr.Gallery(ids=[report1.id, report2.id])]\n",
     ")\n",
     "report4.save()"
@@ -939,7 +939,7 @@
     "report = wr.Report(\n",
     "    PROJECT,\n",
     "    title=\"Report with markdown\",\n",
-    "    description=\"See what's possible with MarkdownBlock and MarkdownPanel\"\n",
+    "    description=\"See what's possible with MarkdownBlock and MarkdownPanel\",\n",
     "    blocks=[\n",
     "        wr.MarkdownBlock(markdown),\n",
     "        wr.PanelGrid(\n",
@@ -1082,7 +1082,7 @@
     "report = wr.Report(\n",
     "    project=PROJECT,\n",
     "    title=\"Parallel Coordinates Example (all-in-one)\",\n",
-    "    description=\"Using the pytorch sweeps demo (same as the other one but written in one expression)\"\n",
+    "    description=\"Using the pytorch sweeps demo (same as the other one but written in one expression)\",\n",
     "    blocks=[\n",
     "        wr.PanelGrid(\n",
     "            runsets=[wr.Runset(project=\"pytorch-sweeps-demo\")],\n",
@@ -1259,7 +1259,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "report = wr.Report(project=PROJECT, title='Adding artifact lineage to reports', \"via WeaveBlockArtifact, WeaveBlockArtifactVersionedFile, or their panel equivalents\")"
+    "report = wr.Report(project=PROJECT, title='Adding artifact lineage to reports', description=\"via WeaveBlockArtifact, WeaveBlockArtifactVersionedFile, or their panel equivalents\")"
    ]
   },
   {
@@ -1597,6 +1597,18 @@
   "kernelspec": {
    "display_name": "Python 3",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,

--- a/colabs/intro/boom.txt
+++ b/colabs/intro/boom.txt
@@ -1,0 +1,1 @@
+tcnuqua1t6tw


### PR DESCRIPTION
# Fix incorrect parameter and syntax errors

```python
                wr.CustomChart(
                    query={'summary': ['val_loss', 'val_acc']},
                    chart_name='wandb/scatter/v0',
                    user_fields={'x': 'val_loss', 'y': 'val_acc'} # change this line
                ),
```

Changed to:
```python
                wr.CustomChart(
                    query={'summary': ['val_loss', 'val_acc']},
                    chart_name='wandb/scatter/v0',
                    chart_fields={'x': 'val_loss', 'y': 'val_acc'}
                ),
 ```           
 
 Additionaly fixed a number of syntax errors (no comma after description='description') in multiple cells of .ipynb

