### PR TITLE
Use shallow git clones in colab notebooks

### DIFF
--- a/colabs/convnext/Finetune_ConvNext_on_CIFAR10_using_W&B.ipynb
+++ b/colabs/convnext/Finetune_ConvNext_on_CIFAR10_using_W&B.ipynb
@@ -46,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!git clone https://github.com/facebookresearch/ConvNeXt"
+    "!git clone --depth 1 https://github.com/facebookresearch/ConvNeXt"
    ]
   },
   {
@@ -80,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!git clone https://github.com/YoongiKim/CIFAR-10-images"
+    "!git clone --depth 1 https://github.com/YoongiKim/CIFAR-10-images"
    ]
   },
   {

--- a/colabs/kaolin_wisp/VQAD.ipynb
+++ b/colabs/kaolin_wisp/VQAD.ipynb
@@ -42,7 +42,7 @@
     "%cd ..\n",
     "\n",
     "# Install Kaolin-Wisp\n",
-    "!git clone https://github.com/NVIDIAGameWorks/kaolin-wisp\n",
+    "!git clone --depth 1 https://github.com/NVIDIAGameWorks/kaolin-wisp\n",
     "%cd kaolin-wisp\n",
     "!pip install -q -r requirements.txt\n",
     "!pip install -q --upgrade wandb\n",

--- a/colabs/keras/keras_core/monai_medmnist_keras.ipynb
+++ b/colabs/keras/keras_core/monai_medmnist_keras.ipynb
@@ -57,7 +57,7 @@
     "# install the `main` branch of KerasCore\n",
     "!pip install -qq namex\n",
     "!apt install python3.10-venv\n",
-    "!git clone https://github.com/soumik12345/keras-core.git && cd keras-core && python pip_build.py --install\n",
+    "!git clone --depth 1 https://github.com/soumik12345/keras-core.git && cd keras-core && python pip_build.py --install\n",
     "\n",
     "# install monai and wandb-addons\n",
     "!pip install -qq git+https://github.com/soumik12345/wandb-addons\n",

--- a/colabs/keras/keras_core/timm_keras.ipynb
+++ b/colabs/keras/keras_core/timm_keras.ipynb
@@ -55,7 +55,7 @@
     "# install the `main` branch of KerasCore\n",
     "!pip install -qq namex\n",
     "!apt install python3.10-venv\n",
-    "!git clone https://github.com/soumik12345/keras-core.git && cd keras-core && python pip_build.py --install\n",
+    "!git clone --depth 1 https://github.com/soumik12345/keras-core.git && cd keras-core && python pip_build.py --install\n",
     "\n",
     "# install timm and wandb-addons\n",
     "!pip install -qq git+https://github.com/soumik12345/wandb-addons"

--- a/colabs/keras/keras_core/torchvision-keras.ipynb
+++ b/colabs/keras/keras_core/torchvision-keras.ipynb
@@ -50,7 +50,7 @@
     "# install the `main` branch of KerasCore\n",
     "!pip install -qq namex\n",
     "!apt install python3.10-venv\n",
-    "!git clone https://github.com/soumik12345/keras-core.git && cd keras-core && python pip_build.py --install\n",
+    "!git clone --depth 1 https://github.com/soumik12345/keras-core.git && cd keras-core && python pip_build.py --install\n",
     "\n",
     "# install wandb-addons\n",
     "!pip install -qq git+https://github.com/soumik12345/wandb-addons"

--- a/colabs/paddlepaddle/paddledetection/PaddleDetection_and_W&B_Your_one_stop_for_everything_object_detection.ipynb
+++ b/colabs/paddlepaddle/paddledetection/PaddleDetection_and_W&B_Your_one_stop_for_everything_object_detection.ipynb
@@ -70,7 +70,7 @@
    "outputs": [],
    "source": [
     "%%shell\n",
-    "git clone https://github.com/PaddlePaddle/PaddleDetection\n",
+    "git clone --depth 1 https://github.com/PaddlePaddle/PaddleDetection\n",
     "python -m pip install paddlepaddle-gpu==2.3.2.post112 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html\n",
     "pip install pyclipper attrdict gdown -qqq\n",
     "cd PaddleDetection\n",

--- a/colabs/paddlepaddle/paddleocr/Train_and_Debug_Your_OCR_Models_with_PaddleOCR_and_W&B.ipynb
+++ b/colabs/paddlepaddle/paddleocr/Train_and_Debug_Your_OCR_Models_with_PaddleOCR_and_W&B.ipynb
@@ -65,7 +65,7 @@
    "outputs": [],
    "source": [
     "\n",
-    "!git clone https://github.com/PaddlePaddle/PaddleOCR\n",
+    "!git clone --depth 1 https://github.com/PaddlePaddle/PaddleOCR\n",
     "!python -m pip install paddlepaddle-gpu==2.3.2.post112 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html\n",
     "!pip install pyclipper attrdict opencv-python shapely scikit-image imgaug -qqq\n",
     "!cd PaddleOCR && pip install -r requirements.txt && pip install -e ."

--- a/colabs/stylegan_nada/StyleGAN-NADA.ipynb
+++ b/colabs/stylegan_nada/StyleGAN-NADA.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!git clone https://github.com/yuval-alaluf/restyle-encoder.git $restyle_dir\n",
+    "!git clone --depth 1 https://github.com/yuval-alaluf/restyle-encoder.git $restyle_dir\n",
     "\n",
     "!wget https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip\n",
     "!sudo unzip ninja-linux.zip -d /usr/local/bin/\n",
@@ -71,8 +71,8 @@
     "!pip install ftfy regex tqdm wandb\n",
     "!pip install git+https://github.com/openai/CLIP.git\n",
     "\n",
-    "!git clone https://github.com/NVlabs/stylegan2-ada/ $stylegan_ada_dir\n",
-    "!git clone https://github.com/rinongal/stylegan-nada.git $stylegan_nada_dir"
+    "!git clone --depth 1 https://github.com/NVlabs/stylegan2-ada/ $stylegan_ada_dir\n",
+    "!git clone --depth 1 https://github.com/rinongal/stylegan-nada.git $stylegan_nada_dir"
    ]
   },
   {

--- a/colabs/torchtune/torchtune_and_wandb.ipynb
+++ b/colabs/torchtune/torchtune_and_wandb.ipynb
@@ -45,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!git clone https://github.com/pytorch/torchtune"
+    "!git clone --depth 1 https://github.com/pytorch/torchtune"
    ]
   },
   {

--- a/colabs/wandb-log/Log_(Almost)_Anything_with_W&B_Media.ipynb
+++ b/colabs/wandb-log/Log_(Almost)_Anything_with_W&B_Media.ipynb
@@ -56,7 +56,7 @@
     "!pip install wandb -qq\n",
     "\n",
     "# Fetch audio, video and other data files to log\n",
-    "!git clone https://github.com/wandb/examples.git\n",
+    "!git clone --depth 1 https://github.com/wandb/examples.git\n",
     "!pip install soundfile -qq\n",
     "\n",
     "import warnings\n",

--- a/colabs/wandb-log/Run_names_visualized_using_min_dalle.ipynb
+++ b/colabs/wandb-log/Run_names_visualized_using_min_dalle.ipynb
@@ -35,7 +35,7 @@
    "outputs": [],
    "source": [
     "#@title Setup\n",
-    "! git clone https://github.com/kuprel/min-dalle\n",
+    "! git clone --depth 1 https://github.com/kuprel/min-dalle\n",
     "! git lfs install\n",
     "! git clone https://huggingface.co/dalle-mini/vqgan_imagenet_f16_16384 /content/min-dalle/pretrained/vqgan\n",
     "!pip install torch flax==0.4.2 wandb\n",

--- a/colabs/yolo/Logging_YOLOv5_Experiments_with_W&B.ipynb
+++ b/colabs/yolo/Logging_YOLOv5_Experiments_with_W&B.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!git clone https://github.com/ultralytics/yolov5  # clone repo\n",
+    "!git clone --depth 1 https://github.com/ultralytics/yolov5  # clone repo\n",
     "%cd yolov5\n",
     "%pip install -qr requirements.txt  # install dependencies\n",
     "\n",

--- a/colabs/yolo/Train_YOLOv5_model_on_a_Custom_Dataset_with_Weights_&_Biases.ipynb
+++ b/colabs/yolo/Train_YOLOv5_model_on_a_Custom_Dataset_with_Weights_&_Biases.ipynb
@@ -66,7 +66,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!git clone https://github.com/ultralytics/yolov5.git\n",
+    "!git clone --depth 1 https://github.com/ultralytics/yolov5.git\n",
     "%cd /content/yolov5\n",
     "!pip install -r requirements.txt\n",
     "!pip install wandb==0.12.10"

--- a/colabs/yolo/Train_and_Debug_YOLOv5_Models_with_Weights_&_Biases_.ipynb
+++ b/colabs/yolo/Train_and_Debug_YOLOv5_Models_with_Weights_&_Biases_.ipynb
@@ -77,7 +77,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!git clone https://github.com/ultralytics/yolov5.git\n",
+    "!git clone --depth 1 https://github.com/ultralytics/yolov5.git\n",
     "!curl -L \"https://public.roboflow.com/ds/1BpjFZe9ST?key=KXD7eDvwTa\" > roboflow.zip; unzip -o roboflow.zip; rm roboflow.zip\n",
     "%cd /content/yolov5\n",
     "!pip install -r requirements.txt\n",

--- a/colabs/yolo/Wildfire_Smoke_Detection_with_YOLOv5,_Roboflow_and_Weights_&_Biases (1).ipynb
+++ b/colabs/yolo/Wildfire_Smoke_Detection_with_YOLOv5,_Roboflow_and_Weights_&_Biases (1).ipynb
@@ -65,7 +65,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!git clone https://github.com/ultralytics/yolov5.git\n",
+    "!git clone --depth 1 https://github.com/ultralytics/yolov5.git\n",
     "!curl -L \"https://app.roboflow.com/ds/5F7B42TQI7?key=VhVxco4lnb\" > roboflow.zip; unzip roboflow.zip; rm roboflow.zip\n",
     "%cd /content/yolov5\n",
     "!pip install -r requirements.txt\n",


### PR DESCRIPTION
- Makes the clone operation much faster
- Reduces the size of the clone
- Minimal risk of impacting the functionality of the notebooks, which do not operate on the Git history
- If a reader can't use shallow clones, it's self-documenting what to change to undo it

Fixes https://wandb.atlassian.net/browse/GROWTH2-361