### PR TITLE
Update examples for scim patch endpoint with RFC compliant payloads

### DIFF
--- a/wandb-scim/examples/teams_example.py
+++ b/wandb-scim/examples/teams_example.py
@@ -80,25 +80,52 @@ def add_members(teams, team_id, member_ids):
     except requests.exceptions.RequestException as e:
         print(f"Error occurred during API request: {str(e)}")
 
-def remove_members(teams, team_id, member_ids):
+def remove_member(teams, team_id, member_id):
     """
-    Updates a team by removing members.
+    Updates a team by removing a specific member.
 
     Args:
         teams (Teams): An instance of the Teams class.
         team_id (str): The ID of the team to update.
-        member_ids (list): The IDs of the members to removed from the team.
+        member_id (str): The ID of the member to be removed from the team.
     """
     try:
-        # Update team by removing members
-        member_object = []
-        for id in member_ids:
-            member_object.append({"value": id})
-        remove_members_response = teams.remove_members(
-            team_id,
-            member_object
-        )
-        print(remove_members_response)
+        # Update team by removing a specific member
+        remove_member_response = teams.remove_member(team_id, member_id)
+        print(remove_member_response)
+    except requests.exceptions.RequestException as e:
+        print(f"Error occurred during API request: {str(e)}")
+
+def remove_multiple_members(teams, team_id, member_ids):
+    """
+    Updates a team by removing multiple members (one API call per member).
+
+    Args:
+        teams (Teams): An instance of the Teams class.
+        team_id (str): The ID of the team to update.
+        member_ids (list): The IDs of the members to be removed from the team.
+    """
+    try:
+        # Remove each member individually since API only supports one operation at a time
+        for member_id in member_ids:
+            print(f"Removing member: {member_id}")
+            remove_member_response = teams.remove_member(team_id, member_id)
+            print(remove_member_response)
+    except requests.exceptions.RequestException as e:
+        print(f"Error occurred during API request: {str(e)}")
+
+def remove_all_members(teams, team_id):
+    """
+    Removes all members from a team.
+
+    Args:
+        teams (Teams): An instance of the Teams class.
+        team_id (str): The ID of the team to remove all members from.
+    """
+    try:
+        # Remove all members from the team
+        remove_all_response = teams.remove_all_members(team_id)
+        print(remove_all_response)
     except requests.exceptions.RequestException as e:
         print(f"Error occurred during API request: {str(e)}")
 
@@ -115,4 +142,6 @@ if __name__ == "__main__":
     # create_team(teams, "team-name-asdfghjsdfgh",["VXNlcjoxNjg1NzA5"])
     # get_team(teams, "team_id")
     # add_members(teams, "RW50aXR5OjIyMTgyMjI=", ["VXNlcjoxODcxODU1", "VXNlcjoxNjg1NzA5"])
-    # remove_members(teams, "RW50aXR5OjIyMTgyMjI=", ["VXNlcjoxODcxODU1", "VXNlcjoxNjg1NzA5"])
+    # remove_member(teams, "RW50aXR5OjIyMTgyMjI=", "VXNlcjoxODcxODU1")  # Remove single member
+    # remove_multiple_members(teams, "RW50aXR5OjIyMTgyMjI=", ["VXNlcjoxODcxODU1", "VXNlcjoxNjg1NzA5"])  # Remove multiple members
+    # remove_all_members(teams, "RW50aXR1OjIyMTgyMjI=")  # Remove all members

--- a/wandb-scim/teams.py
+++ b/wandb-scim/teams.py
@@ -138,27 +138,25 @@ class Teams(object):
         else:
             return f"Failed to update team. Status code: {response.status_code}"
 
-    def remove_members(self, team_id, request_payload):
+    def remove_member(self, team_id, member_id):
         """
-        Removes members from the team.
+        Removes a specific member from the team using path filters.
 
         Args:
             team_id (str): team_id of the team_id.
-            request_payload (list[dict]): The payload containing members information.
-                It should contain the following key in each element:
-                    - 'value': The id of the member to be removed from the team.
+            member_id (str): The id of the member to be removed from the team.
 
         Returns:
             str: A message indicating whether the member removal was successful or failed.
         """
         print("Removing member from the team")
+        
         data = {
             "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
             "Operations": [
                 {
                     "op": "remove",
-                    "path": "members",
-                    "value": request_payload
+                    "path": f"members[value eq \"{member_id}\"]"
                 }
             ]
         }
@@ -174,6 +172,44 @@ class Teams(object):
             updated_data = response.json()  # Get the updated resource data from the response
             print("Updated Data:", updated_data)
             return "Team updated successfully"
+
+        elif response.status_code == 404:
+            return "Team not found"
+        else:
+            return f"Failed to update team. Status code: {response.status_code}"
+
+    def remove_all_members(self, team_id):
+        """
+        Removes all members from the team.
+
+        Args:
+            team_id (str): team_id of the team_id.
+
+        Returns:
+            str: A message indicating whether removing all members was successful or failed.
+        """
+        print("Removing all members from the team")
+        data = {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            "Operations": [
+                {
+                    "op": "remove",
+                    "path": "members"
+                }
+            ]
+        }
+        headers = {
+            "Authorization": self.authorization_header,
+            "Content-Type": "application/json"
+        }
+        # Send a PATCH request to remove all members from the team
+        url = f"{self.base_url}/scim/Groups/{team_id}"
+        response = requests.patch(url, json=data, headers=headers)
+
+        if response.status_code == 200:
+            updated_data = response.json()  # Get the updated resource data from the response
+            print("Updated Data:", updated_data)
+            return "All team members removed successfully"
 
         elif response.status_code == 404:
             return "Team not found"


### PR DESCRIPTION
I recently updated our SCIM Patch endpoint to be compliant with the RFC. We want to encourage users to use this new payload format when interacting with our SCIM endpoints, so I've updated the examples to reflect the new payload format.