### PR TITLE
Fix teble/table typo in Intro_to_Weights_&_Biases.ipynb

### DIFF
--- a/colabs/intro/Intro_to_Weights_&_Biases.ipynb
+++ b/colabs/intro/Intro_to_Weights_&_Biases.ipynb
@@ -224,7 +224,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Create a teble to compare the predicted values versus the true value\n",
+    "### Create a table to compare the predicted values versus the true value\n",
     "\n",
     "The following cell is unique to W&B, so let's go over it.\n",
     "\n",


### PR DESCRIPTION
`teble` should be `table`