### PR TITLE
[DOCS-970] Add Colab to demonstrate chart expressions

### DIFF
--- a/colabs/chart_expressions/chart_expressions_demo.ipynb
+++ b/colabs/chart_expressions/chart_expressions_demo.ipynb
@@ -1,0 +1,590 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "LkXDleyUxy8F"
+      },
+      "source": [
+        "# W&B chart expressions demo: Creating Derived Metrics in Charts\n",
+        "\n",
+        "Expressions allow you to perform mathematical operations on logged metrics to create new derived values. This notebook demonstrates some ways to use expressions to:\n",
+        "- Convert one metric to another, such as by converting accuracy to error rate.\n",
+        "- Calculate the ratios of two metrics.\n",
+        "- Scale values for better visualization."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "WSVGhWH_xy8H"
+      },
+      "outputs": [],
+      "source": [
+        "# Install W&B\n",
+        "!pip install wandb -q"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 191
+        },
+        "id": "KXL7Q7Bgxy8I",
+        "outputId": "554a13d7-8468-4c59-d8a2-dd0868011eb1"
+      },
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Javascript object>"
+            ],
+            "application/javascript": [
+              "\n",
+              "        window._wandbApiKey = new Promise((resolve, reject) => {\n",
+              "            function loadScript(url) {\n",
+              "            return new Promise(function(resolve, reject) {\n",
+              "                let newScript = document.createElement(\"script\");\n",
+              "                newScript.onerror = reject;\n",
+              "                newScript.onload = resolve;\n",
+              "                document.body.appendChild(newScript);\n",
+              "                newScript.src = url;\n",
+              "            });\n",
+              "            }\n",
+              "            loadScript(\"https://cdn.jsdelivr.net/npm/postmate/build/postmate.min.js\").then(() => {\n",
+              "            const iframe = document.createElement('iframe')\n",
+              "            iframe.style.cssText = \"width:0;height:0;border:none\"\n",
+              "            document.body.appendChild(iframe)\n",
+              "            const handshake = new Postmate({\n",
+              "                container: iframe,\n",
+              "                url: 'https://wandb.ai/authorize'\n",
+              "            });\n",
+              "            const timeout = setTimeout(() => reject(\"Couldn't auto authenticate\"), 5000)\n",
+              "            handshake.then(function(child) {\n",
+              "                child.on('authorize', data => {\n",
+              "                    clearTimeout(timeout)\n",
+              "                    resolve(data)\n",
+              "                });\n",
+              "            });\n",
+              "            })\n",
+              "        });\n",
+              "    "
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "\u001b[34m\u001b[1mwandb\u001b[0m: Logging into wandb.ai. (Learn how to deploy a W&B server locally: https://wandb.me/wandb-server)\n",
+            "\u001b[34m\u001b[1mwandb\u001b[0m: You can find your API key in your browser here: https://wandb.ai/authorize\n",
+            "wandb: Paste an API key from your profile and hit enter:"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            " ··········\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "\u001b[34m\u001b[1mwandb\u001b[0m: \u001b[33mWARNING\u001b[0m If you're specifying your api key in code, ensure this code is not shared publicly.\n",
+            "\u001b[34m\u001b[1mwandb\u001b[0m: \u001b[33mWARNING\u001b[0m Consider setting the WANDB_API_KEY environment variable, or running `wandb login` from the command line.\n",
+            "\u001b[34m\u001b[1mwandb\u001b[0m: No netrc file found, creating one.\n",
+            "\u001b[34m\u001b[1mwandb\u001b[0m: Appending key for api.wandb.ai to your netrc file: /root/.netrc\n",
+            "\u001b[34m\u001b[1mwandb\u001b[0m: Currently logged in as: \u001b[33mmatt-linville\u001b[0m (\u001b[33mwandb\u001b[0m) to \u001b[32mhttps://api.wandb.ai\u001b[0m. Use \u001b[1m`wandb login --relogin`\u001b[0m to force relogin\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "True"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 2
+        }
+      ],
+      "source": [
+        "import wandb\n",
+        "import numpy as np\n",
+        "import random\n",
+        "import time\n",
+        "\n",
+        "# Initialize W&B\n",
+        "wandb.login()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "mRMp0nxHxy8I"
+      },
+      "source": [
+        "## Example 1: Train a simple model\n",
+        "\n",
+        "Let's simulate a training run and log some metrics, so that we can create some charts that use expressions."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 722
+        },
+        "id": "6Zo7sGFxxy8I",
+        "outputId": "6f70febf-1ab4-441b-f3db-8263e9e34c8d"
+      },
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              "Tracking run with wandb version 0.21.0"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              "Run data is saved locally in <code>/content/wandb/run-20250729_200345-fjg1cqde</code>"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              "Syncing run <strong><a href='https://wandb.ai/wandb/expression-demo/runs/fjg1cqde' target=\"_blank\">training-example</a></strong> to <a href='https://wandb.ai/wandb/expression-demo' target=\"_blank\">Weights & Biases</a> (<a href='https://wandb.me/developer-guide' target=\"_blank\">docs</a>)<br>"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              " View project at <a href='https://wandb.ai/wandb/expression-demo' target=\"_blank\">https://wandb.ai/wandb/expression-demo</a>"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              " View run at <a href='https://wandb.ai/wandb/expression-demo/runs/fjg1cqde' target=\"_blank\">https://wandb.ai/wandb/expression-demo/runs/fjg1cqde</a>"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Training complete! View your run at: https://wandb.ai/wandb/expression-demo/runs/fjg1cqde\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": []
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              "<br>    <style><br>        .wandb-row {<br>            display: flex;<br>            flex-direction: row;<br>            flex-wrap: wrap;<br>            justify-content: flex-start;<br>            width: 100%;<br>        }<br>        .wandb-col {<br>            display: flex;<br>            flex-direction: column;<br>            flex-basis: 100%;<br>            flex: 1;<br>            padding: 10px;<br>        }<br>    </style><br><div class=\"wandb-row\"><div class=\"wandb-col\"><h3>Run history:</h3><br/><table class=\"wandb\"><tr><td>accuracy</td><td>▁▁▁▂▂▂▂▂▂▂▂▃▃▃▄▄▄▄▄▄▄▄▅▅▅▆▅▅▆▆▆▇▆▇▇▇██▇█</td></tr><tr><td>epoch</td><td>▁▁▁▁▂▂▂▂▂▃▃▃▃▃▃▄▄▄▄▄▅▅▅▅▅▅▆▆▆▆▆▆▇▇▇▇▇▇██</td></tr><tr><td>learning_rate</td><td>███████▆▆▆▆▆▆▆▆▄▄▄▄▄▄▄▄▄▃▃▃▃▃▃▃▃▁▁▁▁▁▁▁▁</td></tr><tr><td>loss</td><td>█▇▇▆▅▄▄▄▃▃▃▃▂▂▂▂▂▂▂▂▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>memory_total</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>memory_used</td><td>▁▁▁▁▂▂▂▂▃▃▃▃▃▃▄▄▄▄▄▄▄▅▅▅▅▆▆▅▆▆▆▆▇▇▇▇▇███</td></tr><tr><td>val_accuracy</td><td>▁▁▂▂▂▂▂▂▂▂▂▂▃▄▄▄▃▄▄▄▅▅▅▅▅▅▅▆▆▆▆▆▇▇▇▇▇███</td></tr><tr><td>val_loss</td><td>█▇▇▆▆▅▄▄▄▄▃▃▃▂▂▂▂▂▂▂▂▁▂▁▂▁▁▂▂▁▁▁▁▁▁▁▁▁▁▁</td></tr></table><br/></div><div class=\"wandb-col\"><h3>Run summary:</h3><br/><table class=\"wandb\"><tr><td>accuracy</td><td>0.89661</td></tr><tr><td>epoch</td><td>49</td></tr><tr><td>learning_rate</td><td>0.00081</td></tr><tr><td>loss</td><td>0.0405</td></tr><tr><td>memory_total</td><td>8000</td></tr><tr><td>memory_used</td><td>2001.72529</td></tr><tr><td>val_accuracy</td><td>0.86693</td></tr><tr><td>val_loss</td><td>0.15748</td></tr></table><br/></div></div>"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              " View run <strong style=\"color:#cdcd00\">training-example</strong> at: <a href='https://wandb.ai/wandb/expression-demo/runs/fjg1cqde' target=\"_blank\">https://wandb.ai/wandb/expression-demo/runs/fjg1cqde</a><br> View project at: <a href='https://wandb.ai/wandb/expression-demo' target=\"_blank\">https://wandb.ai/wandb/expression-demo</a><br>Synced 5 W&B file(s), 0 media file(s), 3 artifact file(s) and 0 other file(s)"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              "Find logs at: <code>./wandb/run-20250729_200345-fjg1cqde/logs</code>"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "source": [
+        "# Start a new run\n",
+        "run = wandb.init(\n",
+        "    project=\"expression-demo\",\n",
+        "    name=\"training-example\",\n",
+        "    config={\n",
+        "        \"learning_rate\": 0.001,\n",
+        "        \"batch_size\": 32,\n",
+        "        \"epochs\": 50\n",
+        "    }\n",
+        ")\n",
+        "\n",
+        "# Simulate training metrics\n",
+        "epochs = 50\n",
+        "for epoch in range(epochs):\n",
+        "    # Simulate improving accuracy\n",
+        "    accuracy = 0.5 + (0.4 * epoch / epochs) + random.uniform(-0.02, 0.02)\n",
+        "    accuracy = min(accuracy, 0.98)\n",
+        "\n",
+        "    # Simulate decreasing loss\n",
+        "    loss = 2.0 * np.exp(-epoch / 10) + random.uniform(-0.05, 0.05)\n",
+        "\n",
+        "    # Simulate validation metrics (slightly worse than training)\n",
+        "    val_accuracy = accuracy - random.uniform(0.02, 0.05)\n",
+        "    val_loss = loss + random.uniform(0.05, 0.15)\n",
+        "\n",
+        "    # Simulate learning rate decay\n",
+        "    learning_rate = 0.001 * (0.95 ** (epoch // 10))\n",
+        "\n",
+        "    # Simulate memory usage\n",
+        "    memory_used = 1000 + epoch * 20 + random.uniform(-50, 50)\n",
+        "    memory_total = 8000\n",
+        "\n",
+        "    # Log metrics\n",
+        "    wandb.log({\n",
+        "        \"epoch\": epoch,\n",
+        "        \"accuracy\": accuracy,\n",
+        "        \"loss\": loss,\n",
+        "        \"val_accuracy\": val_accuracy,\n",
+        "        \"val_loss\": val_loss,\n",
+        "        \"learning_rate\": learning_rate,\n",
+        "        \"memory_used\": memory_used,\n",
+        "        \"memory_total\": memory_total\n",
+        "    })\n",
+        "\n",
+        "    time.sleep(0.1)  # Small delay to simulate training time\n",
+        "\n",
+        "print(f\"Training complete! View your run at: {run.url}\")\n",
+        "wandb.finish()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "mJq6Oogzxy8J"
+      },
+      "source": [
+        "## How to Use Expressions in W&B\n",
+        "\n",
+        "After running the cell above, click on the run URL to open your W&B dashboard. Then:\n",
+        "\n",
+        "1. **Create a Line Plot Panel**: Click \"Add Panel\" → \"Line Plot\"\n",
+        "2. **Select a Metric**: Choose one metric (e.g., `accuracy`)\n",
+        "3. **Add an Expression**: In the panel settings, find the \"Expression\" field\n",
+        "4. **Try These Examples**:\n",
+        "\n",
+        "### Example Expressions to Try:\n",
+        "\n",
+        "#### 1. Error Rate\n",
+        "```\n",
+        "1 - accuracy\n",
+        "```\n",
+        "This shows how error decreases as accuracy improves.\n",
+        "\n",
+        "\n",
+        "#### 2. Percentage Accuracy\n",
+        "```\n",
+        "accuracy * 100\n",
+        "```\n",
+        "Displays accuracy as a percentage (0-100 instead of 0-1).\n",
+        "\n",
+        "#### 3. Overfitting Indicator\n",
+        "```\n",
+        "loss / val_loss\n",
+        "```\n",
+        "Values > 1 suggest overfitting (training loss lower than validation).\n",
+        "\n",
+        "#### 4. Learning Rate (Scaled)\n",
+        "```\n",
+        "learning_rate * 1000\n",
+        "```\n",
+        "Makes the small learning rate values more visible.\n",
+        "\n",
+        "#### 5. Memory Usage Percentage\n",
+        "```\n",
+        "memory_used / memory_total * 100\n",
+        "```\n",
+        "Shows memory usage as a percentage."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "k5lDsGZixy8J"
+      },
+      "source": [
+        "## Example 2: Classification Metrics\n",
+        "\n",
+        "Let's create another run with precision and recall to demonstrate F1 score calculation."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 508
+        },
+        "id": "LzgUSoGfxy8J",
+        "outputId": "7bbe0302-6164-4ca7-b13e-194b5ce572c8"
+      },
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              "Tracking run with wandb version 0.21.0"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              "Run data is saved locally in <code>/content/wandb/run-20250729_201120-795xoboi</code>"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              "Syncing run <strong><a href='https://wandb.ai/wandb/expression-demo/runs/795xoboi' target=\"_blank\">classification-example</a></strong> to <a href='https://wandb.ai/wandb/expression-demo' target=\"_blank\">Weights & Biases</a> (<a href='https://wandb.me/developer-guide' target=\"_blank\">docs</a>)<br>"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              " View project at <a href='https://wandb.ai/wandb/expression-demo' target=\"_blank\">https://wandb.ai/wandb/expression-demo</a>"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              " View run at <a href='https://wandb.ai/wandb/expression-demo/runs/795xoboi' target=\"_blank\">https://wandb.ai/wandb/expression-demo/runs/795xoboi</a>"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Classification run complete! View at: https://wandb.ai/wandb/expression-demo/runs/795xoboi\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": []
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              "<br>    <style><br>        .wandb-row {<br>            display: flex;<br>            flex-direction: row;<br>            flex-wrap: wrap;<br>            justify-content: flex-start;<br>            width: 100%;<br>        }<br>        .wandb-col {<br>            display: flex;<br>            flex-direction: column;<br>            flex-basis: 100%;<br>            flex: 1;<br>            padding: 10px;<br>        }<br>    </style><br><div class=\"wandb-row\"><div class=\"wandb-col\"><h3>Run history:</h3><br/><table class=\"wandb\"><tr><td>precision</td><td>▁▁▁▂▁▂▂▂▂▃▃▃▃▃▃▃▄▃▄▄▄▄▄▅▆▆▆▇▇▇▇▇▇▇▇█████</td></tr><tr><td>recall</td><td>▂▁▁▂▁▂▂▂▃▃▃▃▃▃▄▄▄▄▅▅▅▅▅▅▅▆▆▆▆▆▆▇▇▇▇▇████</td></tr><tr><td>step</td><td>▁▁▁▁▂▂▂▂▂▂▃▃▃▃▄▄▄▄▄▄▄▄▅▅▅▅▅▆▆▆▆▆▇▇▇▇▇▇██</td></tr></table><br/></div><div class=\"wandb-col\"><h3>Run summary:</h3><br/><table class=\"wandb\"><tr><td>precision</td><td>0.88368</td></tr><tr><td>recall</td><td>0.87713</td></tr><tr><td>step</td><td>99</td></tr></table><br/></div></div>"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              " View run <strong style=\"color:#cdcd00\">classification-example</strong> at: <a href='https://wandb.ai/wandb/expression-demo/runs/795xoboi' target=\"_blank\">https://wandb.ai/wandb/expression-demo/runs/795xoboi</a><br> View project at: <a href='https://wandb.ai/wandb/expression-demo' target=\"_blank\">https://wandb.ai/wandb/expression-demo</a><br>Synced 5 W&B file(s), 0 media file(s), 3 artifact file(s) and 0 other file(s)"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              "Find logs at: <code>./wandb/run-20250729_201120-795xoboi/logs</code>"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "source": [
+        "# Start a new run for classification metrics\n",
+        "run = wandb.init(\n",
+        "    project=\"expression-demo\",\n",
+        "    name=\"classification-example\",\n",
+        "    config={\n",
+        "        \"model\": \"binary_classifier\",\n",
+        "        \"threshold\": 0.5\n",
+        "    }\n",
+        ")\n",
+        "\n",
+        "# Simulate classification metrics\n",
+        "steps = 100\n",
+        "for step in range(steps):\n",
+        "    # Simulate improving precision and recall\n",
+        "    t = step / steps\n",
+        "    precision = 0.6 + 0.3 * t + random.uniform(-0.02, 0.02)\n",
+        "    recall = 0.5 + 0.4 * t + random.uniform(-0.02, 0.02)\n",
+        "\n",
+        "    # Ensure values stay in valid range\n",
+        "    precision = min(max(precision, 0), 1)\n",
+        "    recall = min(max(recall, 0), 1)\n",
+        "\n",
+        "    # Log metrics\n",
+        "    wandb.log({\n",
+        "        \"step\": step,\n",
+        "        \"precision\": precision,\n",
+        "        \"recall\": recall\n",
+        "    })\n",
+        "\n",
+        "    time.sleep(0.05)\n",
+        "\n",
+        "print(f\"Classification run complete! View at: {run.url}\")\n",
+        "wandb.finish()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "fkUZccbHxy8J"
+      },
+      "source": [
+        "### F1 Score Expression\n",
+        "\n",
+        "For the classification run above, you can calculate F1 score using:\n",
+        "\n",
+        "```\n",
+        "2 * (precision * recall) / (precision + recall)\n",
+        "```\n",
+        "\n",
+        "This gives you the harmonic mean of precision and recall.\n",
+        "\n",
+        "## Next Steps\n",
+        "\n",
+        "Try modifying the code above to:\n",
+        "- Log additional metrics (e.g., `true_positives`, `false_positives`).\n",
+        "- Create custom ratios relevant to your use case.\n",
+        "- Experiment with different mathematical transformations.\n",
+        "\n",
+        "Happy experimenting with W&B expressions! 🚀"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8.10"
+    },
+    "colab": {
+      "provenance": []
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
[DOCS-970] Add Colab to demonstrate chart expressions

I worked with Claude Opus to develop this notebook to illustrate docs about using chart expressions. The notebook kicks off two runs and creates expressions using their logged metrics. Tested by uploading the notebook to Colab and running through it to demonstrate each example expression. This notebook needs to be merged before I can update the docs.

Ready for review.

[DOCS-970]: https://wandb.atlassian.net/browse/DOCS-970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ