### PR TITLE
updated padding, fixed unpickling error

### DIFF
--- a/colabs/pytorch-lightning/Fine_tuning_a_Transformer_with_Pytorch_Lightning.ipynb
+++ b/colabs/pytorch-lightning/Fine_tuning_a_Transformer_with_Pytorch_Lightning.ipynb
@@ -206,7 +206,7 @@
     "                      sent,                      # Sentence to encode.\n",
     "                      add_special_tokens = True, # Add '[CLS]' and '[SEP]'\n",
     "                      max_length = 64,           # Pad & truncate all sentences.\n",
-    "                      pad_to_max_length = True,\n",
+    "                      padding='max_length',\n",
     "                      return_attention_mask = True,   # Construct attn. masks.\n",
     "                      return_tensors = 'pt',     # Return pytorch tensors.\n",
     "                   )\n",
@@ -299,7 +299,7 @@
     "  # Download the preprocessed data\n",
     "  pp_data_artifact = run.use_artifact(\"preprocessed-data:latest\")\n",
     "  data_path = pp_data_artifact.get_entry(\"dataset\").download()\n",
-    "  dataset = torch.load(data_path)\n",
+    "  dataset = torch.load(data_path, weights_only=False)\n",
     "\n",
     "  # Calculate the number of samples to include in each set.\n",
     "  train_size = int(0.9 * len(dataset))\n",
@@ -330,6 +330,15 @@
     "## Defining Our Model ⚡\n",
     "\n",
     "We define our model and the associated training + validation procedures in the `LightningModule` below. The model itself is a pre-trained `DistilBertForSequenceClassification` with two labels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch.optim import AdamW"
    ]
   },
   {
@@ -378,15 +387,11 @@
     "    self.log(\"val/acc\", correct/len(ids), on_step=False, on_epoch=True)\n",
     "\n",
     "  def configure_optimizers(self):\n",
-    "    \"\"\"\n",
-    "    This is overriding a LightningModule method that is called to return the\n",
-    "    optimizer used for training.\n",
-    "    \"\"\"\n",
-    "    return transformers.AdamW(\n",
+    "    return AdamW(\n",
     "        self.model.parameters(),\n",
-    "        lr = self.learning_rate, \n",
-    "        eps = 1e-8 \n",
-    "    )\n"
+    "        lr=self.learning_rate,\n",
+    "        eps=1e-8\n",
+    "    )"
    ]
   },
   {
@@ -410,8 +415,8 @@
     "\n",
     "    # Load the datasets from the split-dataset artifact\n",
     "    data = run.use_artifact(\"split-dataset:latest\")\n",
-    "    train_dataset = torch.load(data.get_entry(\"train-data\").download())\n",
-    "    val_dataset = torch.load(data.get_entry(\"validation-data\").download())\n",
+    "    train_dataset = torch.load(data.get_entry(\"train-data\").download(), weights_only=False)\n",
+    "    val_dataset = torch.load(data.get_entry(\"validation-data\").download(), weights_only=False)\n",
     "\n",
     "    # Extract the config object associated with the run\n",
     "    config = run.config\n",


### PR DESCRIPTION
this specific notebook was using the pad_to_max_length which is deprecated. additionally, this notebook was reaching errors on `torch.load` and that is now fixed. this was tested by executing the colab