### PR TITLE
chore(docs): update pytorch colab for deprecation of anonymous mode

### DIFF
--- a/colabs/pytorch/How_does_adding_dropout_affect_model_performance.ipynb
+++ b/colabs/pytorch/How_does_adding_dropout_affect_model_performance.ipynb
@@ -432,7 +432,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wandb.init(project=\"dropout\", anonymous=\"must\")\n",
+    "wandb.init(project=\"dropout\")\n",
     "wandb.watch(net, log=\"all\")\n",
     "\n",
     "for epoch in range(8):\n",


### PR DESCRIPTION
Update pytorch colab to stop using anonymous mode, which was used only 50% of the time in this notebook anyway.,