### PR TITLE
chore(security): update examples for API keys

### DIFF
--- a/colabs/huggingface/Custom_Progress_Callback.ipynb
+++ b/colabs/huggingface/Custom_Progress_Callback.ipynb
@@ -73,7 +73,7 @@
     "\n",
     "## 🔑 Put in your API key\n",
     "\n",
-    "Once you've signed up, run the next cell and click on the link to get your API key and authenticate this notebook."
+    "Once you've signed up, run the next cell. You'll be prompted to create a new API key at [wandb.ai/settings](https://wandb.ai/settings) if you haven't already. Store your API key securely. It can only be viewed once when created."
    ]
   },
   {

--- a/colabs/huggingface/Huggingface_wandb.ipynb
+++ b/colabs/huggingface/Huggingface_wandb.ipynb
@@ -116,7 +116,7 @@
    "metadata": {},
    "source": [
     "## 🔑 Put in your API key\n",
-    "Once you've signed up, run the next cell and click on the link to get your API key and authenticate this notebook."
+    "Once you've signed up, run the next cell. You'll be prompted to create a new API key at [wandb.ai/settings](https://wandb.ai/settings) if you haven't already. Store your API key securely. It can only be viewed once when created."
    ]
   },
   {

--- a/colabs/huggingface/wandb_hf_example.ipynb
+++ b/colabs/huggingface/wandb_hf_example.ipynb
@@ -76,10 +76,10 @@
    "source": [
     "\n",
     "## 🖊️ Sign-up/login\n",
-    "If this is your first time using Weights & Baises or you are not logged in, the link that appears after running `wandb.login()` in the following code cell will take you to sign-up/login page. Signing up for a [free account](https://wandb.ai/signup) is as easy as a few clicks. \n",
+    "If this is your first time using Weights & Biases or you are not logged in, the link that appears after running `wandb.login()` in the following code cell will take you to sign-up/login page. Signing up for a [free account](https://wandb.ai/signup) is as easy as a few clicks. \n",
     "\n",
     "## 🔑 Authentication\n",
-    "Once you've signed up, run the next cell and click on the link to get your API key and authenticate this notebook."
+    "Once you've signed up, run the next cell. You'll be prompted to create a new API key at [wandb.ai/settings](https://wandb.ai/settings) if you haven't already. Store your API key securely. It can only be viewed once when created."
    ]
   },
   {

--- a/colabs/mmdetection/Train_Object_Detector_with_MMDetection_and_W&B.ipynb
+++ b/colabs/mmdetection/Train_Object_Detector_with_MMDetection_and_W&B.ipynb
@@ -144,9 +144,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 4️⃣ Login with you W&B account\n",
+    "### 4️⃣ Login with your W&B account\n",
     "\n",
-    "Create a free W&B account (it's free for personal and academic usage). Visit wandb.ai/authorize to get your unique authentication token. "
+    "Create a free W&B account (it's free for personal and academic usage). Create a new API key at [wandb.ai/settings](https://wandb.ai/settings) and store it securely. API keys can only be viewed once when created. "
    ]
   },
   {

--- a/colabs/mmdetection/Train_an_Object_Detection+Semantic_Segmentation_Model_with_MMDetection_and_W&B.ipynb
+++ b/colabs/mmdetection/Train_an_Object_Detection+Semantic_Segmentation_Model_with_MMDetection_and_W&B.ipynb
@@ -142,9 +142,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 4️⃣ Login with you W&B account\n",
+    "### 4️⃣ Login with your W&B account\n",
     "\n",
-    "Create a free W&B account (it's free for personal and academic usage). Visit [wandb.ai/authorize](https://wandb.ai/authorize) to get your unique authentication token. "
+    "Create a free W&B account (it's free for personal and academic usage). Create a new API key at [wandb.ai/settings](https://wandb.ai/settings) and store it securely. API keys can only be viewed once when created. "
    ]
   },
   {

--- a/colabs/openai/OpenAI_API_Autologger_Quickstart.ipynb
+++ b/colabs/openai/OpenAI_API_Autologger_Quickstart.ipynb
@@ -59,8 +59,7 @@
    "source": [
     "### 🪄 2. Import and call `autolog`\n",
     "\n",
-    "When you call `autolog` you will be prompted to login to Weights & Biases with your api key, which you can find at https://www.wandb.ai/authorize\n",
-    "\n",
+    "When you call `autolog` you will be prompted to login to Weights & Biases. If you haven't already, create a new API key at [wandb.ai/settings](https://wandb.ai/settings) and store it securely. API keys can only be viewed once when created.\n",
     "\n",
     "You can optionally pass a dictionary with arguments for [wandb.init()](https://docs.wandb.ai/ref/python/init) such as a project name, team name, entity, and more. For more information about wandb.init, see the [API Reference Guide](https://docs.wandb.ai/ref/python/init)."
    ]

--- a/colabs/prompts/W&B_Prompts_with_Custom_Columns.ipynb
+++ b/colabs/prompts/W&B_Prompts_with_Custom_Columns.ipynb
@@ -169,7 +169,7 @@
    "source": [
     "Use LangChain as normal by calling your Agent.\n",
     "\n",
-    " You will see a Weights & Biases run start and you will be asked for your [Weights & Biases API key](wwww.wandb.ai/authorize). Once your enter your API key, the inputs and outputs of your Agent calls will start to be streamed to the Weights & Biases App."
+    "You will see a Weights & Biases run start and you will be prompted to create a new API key at [wandb.ai/settings](https://wandb.ai/settings) if you haven't already. Store your API key securely. It can only be viewed once when created. Once you enter your API key, the inputs and outputs of your Agent calls will start to be streamed to the Weights & Biases App."
    ]
   },
   {
@@ -266,7 +266,7 @@
    "source": [
     "Call wandb.init to start a W&B run. Here you can pass a W&B project name as well as an entity name (if logging to a W&B Team), as well as a config and more. See wandb.init for the full list of arguments.\n",
     "\n",
-    "You will see a Weights & Biases run start and be asked for your [Weights & Biases API key](wwww.wandb.ai/authorize). Once your enter your API key, the inputs and outputs of your Agent calls will start to be streamed to the Weights & Biases App.\n",
+    "You will see a Weights & Biases run start and be prompted to create a new API key at [wandb.ai/settings](https://wandb.ai/settings) if you haven't already. Store your API key securely. It can only be viewed once when created. Once you enter your API key, the inputs and outputs of your Agent calls will start to be streamed to the Weights & Biases App.\n",
     "\n",
     "**Note:** A W&B run supports logging as many traces you needed to a single run, i.e. you can make multiple calls of `run.log` without the need to create a new run each time"
    ]

--- a/colabs/prompts/WandB_LLM_QA_bot.ipynb
+++ b/colabs/prompts/WandB_LLM_QA_bot.ipynb
@@ -101,9 +101,9 @@
     "## Log in to W&B\n",
     "- You can explicitly login using `wandb login` or `wandb.login()` (See below)\n",
     "- Alternatively you can set environment variables. There are several env variables which you can set to change the behavior of W&B logging. The most important are:\n",
-    "    - `WANDB_API_KEY` - find this in your \"Settings\" section under your profile\n",
+    "    - `WANDB_API_KEY` - create a new API key in your \"Settings\" section under your profile at [wandb.ai/settings](https://wandb.ai/settings)\n",
     "    - `WANDB_BASE_URL` - this is the url of the W&B server (You only need this if you are using a private instance)\n",
-    "- Find your API Token in \"Profile\" -> \"Setttings\" in the W&B App\n",
+    "- Create a new API key in \"Profile\" -> \"Settings\" in the W&B App. Store your API key securely. It can only be viewed once when created.\n",
     "\n",
     "![api_token](https://drive.google.com/uc?export=view&id=1Xn7hnn0rfPu_EW0A_-32oCXqDmpA0-kx)"
    ]

--- a/colabs/prompts/WandB_Prompts_Quickstart.ipynb
+++ b/colabs/prompts/WandB_Prompts_Quickstart.ipynb
@@ -179,7 +179,7 @@
    "source": [
     "Use LangChain as normal by calling your Agent.\n",
     "\n",
-    " You will see a Weights & Biases run start and you will be asked for your [Weights & Biases API key](wwww.wandb.ai/authorize). Once your enter your API key, the inputs and outputs of your Agent calls will start to be streamed to the Weights & Biases App."
+    "You will see a Weights & Biases run start and you will be prompted to create a new API key at [wandb.ai/settings](https://wandb.ai/settings) if you haven't already. Store your API key securely. It can only be viewed once when created. Once you enter your API key, the inputs and outputs of your Agent calls will start to be streamed to the Weights & Biases App."
    ]
   },
   {
@@ -266,7 +266,7 @@
    "source": [
     "Call wandb.init to start a W&B run. Here you can pass a W&B project name as well as an entity name (if logging to a W&B Team), as well as a config and more. See wandb.init for the full list of arguments.\n",
     "\n",
-    "You will see a Weights & Biases run start and be asked for your [Weights & Biases API key](wwww.wandb.ai/authorize). Once your enter your API key, the inputs and outputs of your Agent calls will start to be streamed to the Weights & Biases App.\n",
+    "You will see a Weights & Biases run start and be prompted to create a new API key at [wandb.ai/settings](https://wandb.ai/settings) if you haven't already. Store your API key securely. It can only be viewed once when created. Once you enter your API key, the inputs and outputs of your Agent calls will start to be streamed to the Weights & Biases App.\n",
     "\n",
     "**Note:** A W&B run supports logging as many traces you needed to a single run, i.e. you can make multiple calls of `run.log` without the need to create a new run each time"
    ]

--- a/colabs/tensorboard/TensorBoard_and_Weights_and_Biases.ipynb
+++ b/colabs/tensorboard/TensorBoard_and_Weights_and_Biases.ipynb
@@ -39,9 +39,9 @@
     "\n",
     "1️⃣. Sign-up for a free W&B [account here](https://wandb.ai/site)\n",
     "\n",
-    "2️⃣. Get your W&B [API key here](https://wandb.ai/authorize)\n",
+    "2️⃣. Create a new W&B [API key at your settings page](https://wandb.ai/settings) and store it securely. API keys can only be viewed once when created.\n",
     "\n",
-    "3️⃣. Initialise a W&B run with wandb.init and pass in your API key to log in"
+    "3️⃣. Initialise a W&B run with wandb.init and you will be prompted to enter your API key to log in"
    ]
   },
   {

--- a/colabs/wandb-model-registry/Model_Registry_E2E.ipynb
+++ b/colabs/wandb-model-registry/Model_Registry_E2E.ipynb
@@ -60,9 +60,9 @@
     "## Login to W&B\n",
     "- You can explicitly login using `wandb login` or `wandb.login()` (See below)\n",
     "- Alternatively you can set environment variables. There are several env variables which you can set to change the behavior of W&B logging. The most important are:\n",
-    "    - `WANDB_API_KEY` - find this in your \"Settings\" section under your profile \n",
+    "    - `WANDB_API_KEY` - create a new API key in your \"Settings\" section under your profile at [wandb.ai/settings](https://wandb.ai/settings)\n",
     "    - `WANDB_BASE_URL` - this is the url of the W&B server\n",
-    "- Find your API Token in \"Profile\" -> \"Setttings\" in the W&B App\n",
+    "- Create a new API key in \"Profile\" -> \"Settings\" in the W&B App. Store your API key securely. It can only be viewed once when created.\n",
     "\n",
     "![api_token](https://drive.google.com/uc?export=view&id=1Xn7hnn0rfPu_EW0A_-32oCXqDmpA0-kx)"
    ]

--- a/colabs/wandb-model-registry/New_Model_Logging_in_W&B.ipynb
+++ b/colabs/wandb-model-registry/New_Model_Logging_in_W&B.ipynb
@@ -65,9 +65,9 @@
     "## Log in to W&B\n",
     "- You can explicitly login using `wandb login` or `wandb.login()` (See below)\n",
     "- Alternatively you can set environment variables. There are several env variables which you can set to change the behavior of W&B logging. The most important are:\n",
-    "    - `WANDB_API_KEY` - find this in your \"Settings\" section under your profile\n",
+    "    - `WANDB_API_KEY` - create a new API key in your \"Settings\" section under your profile at [wandb.ai/settings](https://wandb.ai/settings)\n",
     "    - `WANDB_BASE_URL` - this is the url of the W&B server\n",
-    "- Find your API Token in \"Profile\" -> \"Setttings\" in the W&B App\n",
+    "- Create a new API key in \"Profile\" -> \"Settings\" in the W&B App. Store your API key securely. It can only be viewed once when created.\n",
     "\n",
     "![api_token](https://drive.google.com/uc?export=view&id=1Xn7hnn0rfPu_EW0A_-32oCXqDmpA0-kx)"
    ]

--- a/examples/llama-cpp/README.md
+++ b/examples/llama-cpp/README.md
@@ -9,9 +9,9 @@ This script automates the evaluation of different LLM's with W&B.  It was origin
 ```bash
 pip install wandb
 
-# Find your api key at https://wandb.ai/authorize
+# Create a new API key at https://wandb.ai/settings and store it securely
 export WANDB_API_KEY=XXX
-# Find your openai api key at https://platform.openai.com/account/api-keys
+# Create a new OpenAI API key at https://platform.openai.com/account/api-keys
 export OPENAI_API_KEY=XXX
 ```
 


### PR DESCRIPTION
Update examples for API keys

- Prefer /settings over /authorize
- Note that you can see the key material only once, and advise to store it securely

Resolves DOCS-1968