### PR TITLE
feat(integrations): Add VAREK Guardrails + W&B pipeline verification …

### DIFF
--- a/examples/varek-guardrails/README.md
+++ b/examples/varek-guardrails/README.md
@@ -1,0 +1,157 @@
+# VAREK Guardrails + Weights & Biases
+
+Three runnable examples demonstrating how to integrate
+[VAREK Guardrails](https://github.com/kwdoug63/varek) — a Python runtime
+containment layer that bounds untrusted code at the Linux kernel via
+seccomp-bpf — with W&B for experiment tracking, telemetry, and CI gating.
+
+## What this directory contains
+
+| File                       | Purpose                                                                                              |
+| -------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `verification_artifact.py` | Runs the public-API verification battery, uploads the structured manifest as a W&B `Artifact`. CI gate. |
+| `telemetry_stream.py`      | Bridges VAREK's `subscribe_telemetry` events into `wandb.log`, producing a kernel-event timeline.    |
+| `benchmark_suite.py`       | Eight-payload regression battery (benign / malicious / resource / edge), logs a sortable `wandb.Table`. |
+| `scripts/with-cgroup.sh`   | Idempotent wrapper that ensures cgroup v2 controllers are enabled before the script runs.            |
+| `requirements.txt`         | Pinned floors: `varek-guardrails>=1.1.1`, `wandb>=0.16`, `weave>=0.50`.                              |
+
+## Why this integration
+
+W&B answers *what happened during the run.* VAREK Guardrails answers
+*was the run permitted to do what it tried.* For agentic workloads where
+an LLM emits code that subsequently executes, the second question is the
+one that matters when something goes wrong — and a W&B Artifact attached
+to the run is the simplest auditable record that the kernel boundary
+fired (or did not).
+
+These examples wire the two together at three different points: as a
+verification artifact (CI gate), as live telemetry (timeline), and as a
+benchmark battery (regression suite).
+
+## Prerequisites
+
+### Linux kernel + cgroup v2
+
+VAREK Guardrails enforces per-execution memory and CPU limits via cgroup
+v2. Required:
+
+- Linux kernel 5.10+
+- cgroup v2 mounted at `/sys/fs/cgroup` (default on Ubuntu 22.04+,
+  Debian 11+, Fedora 31+, RHEL 9+)
+- `libseccomp` available to the Python runtime
+- Root or `CAP_SYS_ADMIN` for the user running the examples (cgroup
+  controllers in `subtree_control` require it)
+
+### Cgroup controller enablement
+
+VAREK Guardrails creates per-execution sub-cgroups under `varek.slice`.
+For those sub-cgroups to support `memory.max` / `cpu.max` / `pids.max`,
+the parent slice must have those controllers enabled in
+`cgroup.subtree_control`. The bundled `scripts/with-cgroup.sh` wrapper
+handles this idempotently — always run the examples through it:
+
+```bash
+chmod +x scripts/with-cgroup.sh
+./scripts/with-cgroup.sh python verification_artifact.py
+./scripts/with-cgroup.sh python telemetry_stream.py
+./scripts/with-cgroup.sh python benchmark_suite.py
+```
+
+If you skip the wrapper on a system where controllers aren't already
+enabled, you'll see:
+
+```
+PermissionError: [Errno 13] Permission denied:
+'/sys/fs/cgroup/varek.slice/exec-XXXX/memory.max'
+```
+
+That is the failure mode the wrapper prevents.
+
+### Python environment
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+wandb login
+```
+
+## Quick start
+
+After installing requirements and authenticating with W&B:
+
+```bash
+chmod +x scripts/with-cgroup.sh
+./scripts/with-cgroup.sh python verification_artifact.py
+```
+
+Expected output: five checks pass, a `varek-guardrails-verification`
+artifact is logged to your W&B project, the script exits 0. Open the
+run URL printed at the end to inspect the manifest.
+
+To run the full demonstration sequence:
+
+```bash
+./scripts/with-cgroup.sh python verification_artifact.py
+./scripts/with-cgroup.sh python telemetry_stream.py
+./scripts/with-cgroup.sh python benchmark_suite.py
+```
+
+## Configuring the W&B project / entity
+
+Each script reads `WANDB_PROJECT` and `WANDB_ENTITY` from the environment.
+Defaults:
+
+| Script                    | Default project                  |
+| ------------------------- | -------------------------------- |
+| `verification_artifact.py` | `varek-guardrails-verification`  |
+| `telemetry_stream.py`     | `varek-guardrails-telemetry`     |
+| `benchmark_suite.py`      | `varek-guardrails-benchmarks`    |
+
+To override:
+
+```bash
+WANDB_PROJECT=my-project WANDB_ENTITY=my-team \
+  ./scripts/with-cgroup.sh python verification_artifact.py
+```
+
+## Using as a CI gate
+
+Both `verification_artifact.py` and `benchmark_suite.py` exit non-zero on
+failure, making them drop-in CI gates:
+
+```yaml
+# .github/workflows/varek-verification.yml
+- name: VAREK Guardrails verification
+  run: ./scripts/with-cgroup.sh python verification_artifact.py
+  env:
+    WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+```
+
+Note: GitHub-hosted runners do not expose the cgroup v2 delegation
+required by `varek_guardrails`. Use a self-hosted Linux runner (or a
+container with the appropriate cgroup mounts) for CI.
+
+## Platform support
+
+| Platform              | Status                                                              |
+| --------------------- | ------------------------------------------------------------------- |
+| Linux (cgroup v2)     | Full enforcement — execve, network, wallclock, memory               |
+| macOS                 | `SeccompBpfBackend.is_available()` returns an explanatory string; the package fails closed rather than silently degrading |
+| Windows               | Same fail-closed behavior as macOS                                  |
+| Docker / Kubernetes   | Requires the container runtime to expose cgroup v2 to the workload  |
+
+Failing closed on unsupported platforms is itself a correctness property
+of VAREK Guardrails — the package will not silently run untrusted code
+without containment.
+
+## Further reading
+
+- VAREK repository: <https://github.com/kwdoug63/varek>
+- Guardrails threat model: <https://github.com/kwdoug63/varek/blob/main/docs/security/threat-model.md>
+- Spec paper (language layer): linked from the main VAREK README
+- Issue #223 (the v1.0 weakness this layer fixed): <https://github.com/kwdoug63/varek/issues/223>
+
+## License
+
+MIT — same as the parent `wandb/examples` repository and the upstream
+VAREK project.

--- a/examples/varek-guardrails/benchmark_suite.py
+++ b/examples/varek-guardrails/benchmark_suite.py
@@ -1,5 +1,5 @@
 """
-benchmark_suite.py — VAREK Guardrails containment regression battery.
+benchmark_suite.py -- VAREK Guardrails containment regression battery.
 
 Runs eight payloads spanning four categories (benign, malicious, resource,
 edge) and verifies the actual outcome matches the expected containment
@@ -9,10 +9,10 @@ behavior diverges from expectation, making it suitable as a CI gate or
 pre-commit hook.
 
 Categories:
-  benign     — payloads that should run to completion (exit_code=0, no containment)
-  malicious  — payloads that should be blocked at the kernel boundary
-  resource   — payloads that should be killed by resource limits
-  edge       — payloads that should fail to parse/execute cleanly
+  benign     -- payloads that should run to completion (exit_code=0, no containment)
+  malicious  -- payloads that should be blocked at the kernel boundary
+  resource   -- payloads that should be killed by resource limits
+  edge       -- payloads that should fail to parse/execute cleanly
 
 Run with the cgroup wrapper:
 

--- a/examples/varek-guardrails/benchmark_suite.py
+++ b/examples/varek-guardrails/benchmark_suite.py
@@ -1,0 +1,246 @@
+"""
+benchmark_suite.py — VAREK Guardrails containment regression battery.
+
+Runs eight payloads spanning four categories (benign, malicious, resource,
+edge) and verifies the actual outcome matches the expected containment
+behavior. Each payload's full outcome is logged as a row in a W&B Table
+for comparison across runs. The script exits non-zero if any payload's
+behavior diverges from expectation, making it suitable as a CI gate or
+pre-commit hook.
+
+Categories:
+  benign     — payloads that should run to completion (exit_code=0, no containment)
+  malicious  — payloads that should be blocked at the kernel boundary
+  resource   — payloads that should be killed by resource limits
+  edge       — payloads that should fail to parse/execute cleanly
+
+Run with the cgroup wrapper:
+
+    ./scripts/with-cgroup.sh python benchmark_suite.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from typing import Callable
+
+import wandb
+
+from varek_guardrails import (
+    ExecutionPayload,
+    SeccompBpfBackend,
+    configure_backend,
+    default_python_policy,
+    execute_untrusted,
+)
+
+
+PROJECT = os.environ.get("WANDB_PROJECT", "varek-guardrails-benchmarks")
+ENTITY = os.environ.get("WANDB_ENTITY")
+
+
+def is_contained(outcome) -> bool:
+    """The kernel boundary fired (or process otherwise didn't exit cleanly)."""
+    return (
+        outcome.exit_code != 0
+        or outcome.killed_by_signal is not None
+        or outcome.violation is not None
+    )
+
+
+@dataclass(frozen=True)
+class Payload:
+    name: str
+    category: str
+    code: str
+    # A predicate over the ExecutionOutcome that returns True when the
+    # observed outcome matches expectations. Each payload supplies its own.
+    expectation: Callable[[object], bool]
+    expectation_description: str
+
+
+SUITE: list[Payload] = [
+    # -- benign ------------------------------------------------------------
+    Payload(
+        name="benign_arithmetic",
+        category="benign",
+        code="print(2 + 2)\n",
+        expectation=lambda o: o.exit_code == 0 and not is_contained(o),
+        expectation_description="exit_code=0, boundary did not fire",
+    ),
+    Payload(
+        name="benign_dict_ops",
+        category="benign",
+        code=(
+            "d = {i: i * 2 for i in range(50)}\n"
+            "print(sum(d.values()))\n"
+        ),
+        expectation=lambda o: o.exit_code == 0 and not is_contained(o),
+        expectation_description="exit_code=0, boundary did not fire",
+    ),
+    # -- malicious ---------------------------------------------------------
+    Payload(
+        name="malicious_subprocess_run",
+        category="malicious",
+        code=(
+            "import subprocess\n"
+            "subprocess.run(['/bin/echo', 'pwned'], check=False)\n"
+            "print('should_be_unreachable')\n"
+        ),
+        expectation=lambda o: is_contained(o) and o.exit_code != 0,
+        expectation_description="contained=True, exit_code!=0 (execve denied)",
+    ),
+    # NOTE: default_python_policy() permits os.system to succeed under the
+    # current varek_guardrails 1.1.1 release because /bin/sh is on the default
+    # binary_allowlist. This payload is preserved as a documented regression
+    # test â if a future policy change blocks /bin/sh execve, the
+    # expectation will diverge and force a deliberate update. To block
+    # os.system explicitly, construct a stricter policy with a
+    # binary_allowlist that excludes /bin/sh.
+    Payload(
+        name="documented_os_system_passthrough",
+        category="known_allowance",
+        code=(
+            "import os\n"
+            "os.system('echo permitted-by-default-policy')\n"
+            "print('completed_via_os_system')\n"
+        ),
+        expectation=lambda o: o.exit_code == 0 and not is_contained(o),
+        expectation_description="exit_code=0, boundary did not fire (default policy permits /bin/sh)",
+    ),
+    Payload(
+        name="malicious_socket_connect",
+        category="malicious",
+        code=(
+            "import socket\n"
+            "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"
+            "s.connect(('1.1.1.1', 80))\n"
+            "print('connected')\n"
+        ),
+        expectation=lambda o: is_contained(o) and o.exit_code != 0,
+        expectation_description="contained=True, exit_code!=0 (network denied)",
+    ),
+    # -- resource ----------------------------------------------------------
+    Payload(
+        name="resource_infinite_loop",
+        category="resource",
+        code="while True:\n    pass\n",
+        expectation=lambda o: o.timed_out and is_contained(o),
+        expectation_description="timed_out=True, boundary fired",
+    ),
+    # -- edge --------------------------------------------------------------
+    Payload(
+        name="edge_syntax_error",
+        category="edge",
+        code="def main(:\n    return 1\n",  # intentionally malformed
+        expectation=lambda o: is_contained(o) and o.exit_code != 0,
+        expectation_description="contained=True, exit_code!=0 (parse failure)",
+    ),
+    Payload(
+        name="edge_runtime_exception",
+        category="edge",
+        code="raise RuntimeError('expected by smoke test')\n",
+        expectation=lambda o: is_contained(o) and o.exit_code != 0,
+        expectation_description="contained=True, exit_code!=0 (uncaught exception)",
+    ),
+]
+
+
+def run_suite() -> tuple[wandb.Table, int]:
+    """Execute every payload and return (wandb.Table, divergence_count)."""
+    table = wandb.Table(
+        columns=[
+            "name",
+            "category",
+            "expected",
+            "matched",
+            "exit_code",
+            "contained",
+            "timed_out",
+            "killed_by_signal",
+            "violation",
+            "wall_clock_s",
+        ]
+    )
+
+    divergences = 0
+
+    for payload in SUITE:
+        ep = ExecutionPayload(
+            interpreter_path=sys.executable, code=payload.code
+        )
+        outcome = execute_untrusted(ep, default_python_policy())
+        matched = payload.expectation(outcome)
+        contained = is_contained(outcome)
+        if not matched:
+            divergences += 1
+
+        marker = "OK" if matched else "DIVERGED"
+        print(
+            f"  [{marker}] {payload.name} ({payload.category}): "
+            f"exit={outcome.exit_code} "
+            f"contained={contained} "
+            f"timed_out={outcome.timed_out} "
+            f"wall={outcome.wall_clock_s:.2f}s"
+        )
+
+        table.add_data(
+            payload.name,
+            payload.category,
+            payload.expectation_description,
+            matched,
+            outcome.exit_code,
+            contained,
+            bool(outcome.timed_out),
+            outcome.killed_by_signal
+            if outcome.killed_by_signal is not None
+            else -1,
+            outcome.violation if outcome.violation is not None else "",
+            outcome.wall_clock_s,
+        )
+
+    return table, divergences
+
+
+def main() -> int:
+    configure_backend(SeccompBpfBackend())
+
+    run = wandb.init(
+        project=PROJECT,
+        entity=ENTITY,
+        job_type="benchmark",
+        config={
+            "n_payloads": len(SUITE),
+            "categories": sorted({p.category for p in SUITE}),
+            "backend": "SeccompBpfBackend",
+        },
+    )
+
+    try:
+        print(
+            f"[benchmark] running {len(SUITE)} payloads against "
+            f"default_python_policy()..."
+        )
+        table, divergences = run_suite()
+
+        match_rate = (len(SUITE) - divergences) / len(SUITE)
+        run.log({"benchmark/results": table})
+        run.summary["benchmark/match_rate"] = match_rate
+        run.summary["benchmark/divergences"] = divergences
+        run.summary["benchmark/all_matched"] = divergences == 0
+
+        print(
+            f"\n[benchmark] match_rate={match_rate:.2%} "
+            f"({len(SUITE) - divergences}/{len(SUITE)})"
+        )
+        print(f"[benchmark] view at {run.url}")
+    finally:
+        run.finish()
+
+    return 0 if divergences == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/varek-guardrails/requirements.txt
+++ b/examples/varek-guardrails/requirements.txt
@@ -1,0 +1,3 @@
+varek-guardrails>=1.1.1
+wandb>=0.16
+weave>=0.50

--- a/examples/varek-guardrails/scripts/with-cgroup.sh
+++ b/examples/varek-guardrails/scripts/with-cgroup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# with-cgroup.sh — ensure cgroup v2 controllers are enabled in varek.slice
+# with-cgroup.sh -- ensure cgroup v2 controllers are enabled in varek.slice
 # before delegating to the wrapped command.
 #
 # This is idempotent and safe to run unconditionally. The 2>/dev/null and

--- a/examples/varek-guardrails/scripts/with-cgroup.sh
+++ b/examples/varek-guardrails/scripts/with-cgroup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# with-cgroup.sh — ensure cgroup v2 controllers are enabled in varek.slice
+# before delegating to the wrapped command.
+#
+# This is idempotent and safe to run unconditionally. The 2>/dev/null and
+# || true guards make it a no-op when controllers are already enabled or
+# when running on a system without cgroup v2 (where varek_guardrails will
+# fail closed at the kernel-availability check anyway).
+#
+# Usage:
+#   ./scripts/with-cgroup.sh python verification_artifact.py
+#   ./scripts/with-cgroup.sh python benchmark_suite.py
+
+set -e
+
+# Ensure varek.slice exists in the cgroup tree.
+mkdir -p /sys/fs/cgroup/varek.slice 2>/dev/null || true
+
+# Enable controllers needed for memory/cpu/pids enforcement on per-execution
+# sub-cgroups. If already enabled, the kernel returns EBUSY which we ignore.
+echo "+memory +cpu +pids" > /sys/fs/cgroup/varek.slice/cgroup.subtree_control 2>/dev/null || true
+
+# Delegate to the wrapped command with all arguments preserved.
+exec "$@"

--- a/examples/varek-guardrails/telemetry_stream.py
+++ b/examples/varek-guardrails/telemetry_stream.py
@@ -1,5 +1,5 @@
 """
-telemetry_stream.py — bridge VAREK Guardrails telemetry into W&B run logs.
+telemetry_stream.py -- bridge VAREK Guardrails telemetry into W&B run logs.
 
 VAREK Guardrails emits PEP 578-style audit events through `subscribe_telemetry`.
 This example subscribes a callback that buffers every event and flushes them
@@ -17,7 +17,7 @@ what each payload tried to do.
 POST-FORK SAFETY NOTE:
   Audit hooks installed via subscribe_telemetry are inherited by forked
   children. VAREK Guardrails uses subprocess.Popen with a preexec_fn
-  (seccomp + cgroup setup) that makes ctypes calls — each ctypes call
+  (seccomp + cgroup setup) that makes ctypes calls -- each ctypes call
   triggers our audit hook in the child. Calling wandb.log directly from
   that context breaks the preexec_fn because wandb's threading state does
   not survive fork. We guard the callback with an os.getpid() check so it

--- a/examples/varek-guardrails/telemetry_stream.py
+++ b/examples/varek-guardrails/telemetry_stream.py
@@ -1,0 +1,209 @@
+"""
+telemetry_stream.py — bridge VAREK Guardrails telemetry into W&B run logs.
+
+VAREK Guardrails emits PEP 578-style audit events through `subscribe_telemetry`.
+This example subscribes a callback that buffers every event and flushes them
+into the active W&B run as structured log entries between payloads.
+
+Three demonstration payloads:
+
+  1. A benign payload that completes cleanly (boundary does not fire).
+  2. A payload that attempts subprocess execution (execve denied).
+  3. A payload that runs an infinite loop (wallclock enforced).
+
+The result is a W&B run timeline showing the kernel boundary firing and
+what each payload tried to do.
+
+POST-FORK SAFETY NOTE:
+  Audit hooks installed via subscribe_telemetry are inherited by forked
+  children. VAREK Guardrails uses subprocess.Popen with a preexec_fn
+  (seccomp + cgroup setup) that makes ctypes calls — each ctypes call
+  triggers our audit hook in the child. Calling wandb.log directly from
+  that context breaks the preexec_fn because wandb's threading state does
+  not survive fork. We guard the callback with an os.getpid() check so it
+  is a no-op in any forked child, and we buffer events to a thread-safe
+  queue that is drained from the main thread between payloads.
+
+Run with the cgroup wrapper:
+
+    ./scripts/with-cgroup.sh python telemetry_stream.py
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+import wandb
+
+from varek_guardrails import (
+    ExecutionPayload,
+    SeccompBpfBackend,
+    configure_backend,
+    default_python_policy,
+    execute_untrusted,
+    subscribe_telemetry,
+)
+
+
+PROJECT = os.environ.get("WANDB_PROJECT", "varek-guardrails-telemetry")
+ENTITY = os.environ.get("WANDB_ENTITY")
+
+# Captured at import time. Any audit-hook callback running with a different
+# pid is in a forked child and must be a no-op.
+_PARENT_PID = os.getpid()
+
+# Thread- and fork-safe event buffer drained between payloads.
+_event_queue: "queue.Queue[tuple[str, str]]" = queue.Queue()
+
+
+def is_contained(outcome) -> bool:
+    """The kernel boundary fired (or process otherwise didn't exit cleanly)."""
+    return (
+        outcome.exit_code != 0
+        or outcome.killed_by_signal is not None
+        or outcome.violation is not None
+    )
+
+
+@dataclass
+class DemoPayload:
+    name: str
+    code: str
+    expected_summary: str
+
+
+PAYLOADS: list[DemoPayload] = [
+    DemoPayload(
+        name="benign_compute",
+        code=(
+            "total = sum(range(1000))\n"
+            "print({'total': total})\n"
+        ),
+        expected_summary="exit_code=0, no boundary events",
+    ),
+    DemoPayload(
+        name="execve_attempt",
+        code=(
+            "import subprocess\n"
+            "subprocess.run(['/bin/echo', 'attempt'], check=False)\n"
+            "print('reached')\n"
+        ),
+        expected_summary="execve denied at kernel; subprocess.Popen audit event",
+    ),
+    DemoPayload(
+        name="wallclock_overrun",
+        code="while True:\n    pass\n",
+        expected_summary="killed at 30s wallclock limit",
+    ),
+]
+
+
+def telemetry_callback(event: str, args: tuple[Any, ...]) -> None:
+    """Audit-hook callback. MUST be safe in post-fork-pre-exec contexts.
+
+    Guards:
+      - Skip if pid != parent (we are in a forked child; doing anything
+        non-trivial here would break the subprocess preexec_fn).
+      - Trap and swallow every exception so a logging bug never propagates
+        out of an audit-hook context (which would corrupt sandbox setup).
+      - Use queue.put_nowait, which is implemented in C and atomic.
+    """
+    try:
+        if os.getpid() != _PARENT_PID:
+            return
+        _event_queue.put_nowait((event, repr(args)[:512]))
+    except Exception:
+        # Never raise from an audit hook.
+        pass
+
+
+def drain_events_to_run(run, label: str) -> int:
+    """Flush all buffered events into the active W&B run. Returns count."""
+    drained: list[tuple[str, str]] = []
+    try:
+        while True:
+            drained.append(_event_queue.get_nowait())
+    except queue.Empty:
+        pass
+
+    for event, args_repr in drained:
+        run.log(
+            {
+                "telemetry/event": event,
+                "telemetry/args_repr": args_repr,
+                "telemetry/payload_label": label,
+            }
+        )
+
+    return len(drained)
+
+
+def run_payload(name: str, code: str, run) -> None:
+    print(f"\n[telemetry] running payload: {name}")
+    payload = ExecutionPayload(interpreter_path=sys.executable, code=code)
+    outcome = execute_untrusted(payload, default_python_policy())
+
+    contained = is_contained(outcome)
+    n_events = drain_events_to_run(run, label=name)
+
+    # Per-payload outcome fields, namespaced so multiple runs are comparable.
+    run.log(
+        {
+            f"payload/{name}/exit_code": outcome.exit_code,
+            f"payload/{name}/contained": int(contained),
+            f"payload/{name}/timed_out": int(outcome.timed_out),
+            f"payload/{name}/wall_clock_s": outcome.wall_clock_s,
+            f"payload/{name}/killed_by_signal": (
+                outcome.killed_by_signal
+                if outcome.killed_by_signal is not None
+                else -1
+            ),
+            f"payload/{name}/n_telemetry_events": n_events,
+        }
+    )
+
+    print(
+        f"  exit_code={outcome.exit_code} "
+        f"contained={contained} "
+        f"timed_out={outcome.timed_out} "
+        f"wall_clock_s={outcome.wall_clock_s:.3f} "
+        f"telemetry_events={n_events}"
+    )
+
+
+def main() -> int:
+    configure_backend(SeccompBpfBackend())
+    subscribe_telemetry(telemetry_callback)
+
+    run = wandb.init(
+        project=PROJECT,
+        entity=ENTITY,
+        job_type="telemetry-demo",
+        config={"backend": "SeccompBpfBackend", "n_payloads": len(PAYLOADS)},
+    )
+
+    try:
+        print(f"[telemetry] streaming events to {run.url}")
+
+        for p in PAYLOADS:
+            run_payload(p.name, p.code, run)
+
+        # Final drain in case any events landed after the last payload.
+        residual = drain_events_to_run(run, label="post_run")
+        if residual:
+            print(f"[telemetry] flushed {residual} residual events post-run")
+
+        run.summary["telemetry/payloads_run"] = len(PAYLOADS)
+        print(f"\n[telemetry] complete. View timeline at {run.url}")
+    finally:
+        run.finish()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/varek-guardrails/verification_artifact.py
+++ b/examples/varek-guardrails/verification_artifact.py
@@ -1,5 +1,5 @@
 """
-verification_artifact.py — VAREK Guardrails verification report uploaded
+verification_artifact.py -- VAREK Guardrails verification report uploaded
 as a W&B Artifact.
 
 Exercises the public VAREK Guardrails API end-to-end and produces a
@@ -47,7 +47,7 @@ def is_contained(outcome) -> bool:
     """Derive containment from outcome fields.
 
     The containment boundary fires when the contained code does not exit
-    cleanly. A benign payload that runs to completion is NOT contained —
+    cleanly. A benign payload that runs to completion is NOT contained --
     there was nothing to contain. This matches the working demo's logic
     in 16-wandb-pipeline-verification-intercept.py.
     """
@@ -208,7 +208,7 @@ def main() -> int:
     for check_fn in CHECKS:
         try:
             r = check_fn()
-        except Exception as exc:  # noqa: BLE001 — record uncaught failures
+        except Exception as exc:  # noqa: BLE001 -- record uncaught failures
             r = CheckResult(check_fn.__name__, False, f"uncaught: {exc!r}")
         marker = "PASS" if r.passed else "FAIL"
         print(f"  [{marker}] {r.name}: {r.detail}")

--- a/examples/varek-guardrails/verification_artifact.py
+++ b/examples/varek-guardrails/verification_artifact.py
@@ -1,0 +1,259 @@
+"""
+verification_artifact.py — VAREK Guardrails verification report uploaded
+as a W&B Artifact.
+
+Exercises the public VAREK Guardrails API end-to-end and produces a
+structured verification manifest attached to a W&B run as an artifact.
+This is intended to be run as a CI gate: any FAIL in the manifest exits
+non-zero, and the artifact is preserved on the W&B run for audit.
+
+Output artifact: `varek-guardrails-verification` (type: verification-report)
+
+Run with the cgroup wrapper to ensure controllers are enabled:
+
+    ./scripts/with-cgroup.sh python verification_artifact.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import socket
+import sys
+import tempfile
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import wandb
+
+from varek_guardrails import (
+    ExecutionPayload,
+    IsolationError,
+    SeccompBpfBackend,
+    configure_backend,
+    default_python_policy,
+    execute_untrusted,
+)
+
+
+PROJECT = os.environ.get("WANDB_PROJECT", "varek-guardrails-verification")
+ENTITY = os.environ.get("WANDB_ENTITY")  # optional; uses default if unset
+
+
+def is_contained(outcome) -> bool:
+    """Derive containment from outcome fields.
+
+    The containment boundary fires when the contained code does not exit
+    cleanly. A benign payload that runs to completion is NOT contained —
+    there was nothing to contain. This matches the working demo's logic
+    in 16-wandb-pipeline-verification-intercept.py.
+    """
+    return (
+        outcome.exit_code != 0
+        or outcome.killed_by_signal is not None
+        or outcome.violation is not None
+    )
+
+
+@dataclass
+class CheckResult:
+    name: str
+    passed: bool
+    detail: str = ""
+    measurements: dict[str, Any] = field(default_factory=dict)
+
+
+def _record_outcome_fields(outcome) -> dict[str, Any]:
+    """Capture every field on ExecutionOutcome plus derived containment."""
+    return {
+        "exit_code": outcome.exit_code,
+        "killed_by_signal": outcome.killed_by_signal,
+        "violation": outcome.violation,
+        "timed_out": outcome.timed_out,
+        "wall_clock_s": outcome.wall_clock_s,
+        "contained_derived": is_contained(outcome),
+        "stdout_len": len(outcome.stdout) if outcome.stdout else 0,
+        "stderr_len": len(outcome.stderr) if outcome.stderr else 0,
+    }
+
+
+def _build_payload(code: str) -> ExecutionPayload:
+    """Construct a payload using the active interpreter."""
+    return ExecutionPayload(interpreter_path=sys.executable, code=code)
+
+
+def check_backend_available() -> CheckResult:
+    """SeccompBpfBackend reports itself ready on a conforming host."""
+    backend = SeccompBpfBackend()
+    reason = backend.is_available()
+    if reason is None:
+        return CheckResult("backend_available", True, "SeccompBpfBackend ready")
+    return CheckResult(
+        "backend_available", False, f"backend unavailable: {reason}"
+    )
+
+
+def check_configure_succeeds() -> CheckResult:
+    """configure_backend accepts a ready backend without raising."""
+    try:
+        configure_backend(SeccompBpfBackend())
+        return CheckResult("configure_succeeds", True)
+    except IsolationError as e:
+        return CheckResult("configure_succeeds", False, f"raised: {e}")
+
+
+def check_benign_payload() -> CheckResult:
+    """A pure-computation script runs to completion without triggering containment."""
+    payload = _build_payload(
+        "total = sum(range(100))\n"
+        "print(f'total={total}')\n"
+    )
+    outcome = execute_untrusted(payload, default_python_policy())
+    fields = _record_outcome_fields(outcome)
+
+    # Benign: clean exit AND containment did NOT fire.
+    if outcome.exit_code == 0 and not is_contained(outcome):
+        return CheckResult(
+            "benign_payload", True, "ran cleanly, boundary did not fire", fields
+        )
+    return CheckResult(
+        "benign_payload",
+        False,
+        f"unexpected exit_code={outcome.exit_code} contained={is_contained(outcome)}",
+        fields,
+    )
+
+
+def check_execve_denied() -> CheckResult:
+    """A subprocess.run attempt is intercepted at the kernel boundary."""
+    payload = _build_payload(
+        "import subprocess\n"
+        "subprocess.run(['/bin/echo', 'should not run'], check=True)\n"
+        "print('reached forbidden code path')\n"
+    )
+    outcome = execute_untrusted(payload, default_python_policy())
+    fields = _record_outcome_fields(outcome)
+
+    # The seccomp-bpf filter denies execve; subprocess raises in
+    # _execute_child, the script exits non-zero, containment fires.
+    if is_contained(outcome) and outcome.exit_code != 0:
+        return CheckResult(
+            "execve_denied",
+            True,
+            "subprocess attempt contained at kernel boundary",
+            fields,
+        )
+    return CheckResult(
+        "execve_denied",
+        False,
+        f"containment did not fire: exit_code={outcome.exit_code}",
+        fields,
+    )
+
+
+def check_wallclock_enforced() -> CheckResult:
+    """An infinite loop is killed at the configured wall-clock limit."""
+    payload = _build_payload("while True:\n    pass\n")
+    outcome = execute_untrusted(payload, default_python_policy())
+    fields = _record_outcome_fields(outcome)
+
+    if outcome.timed_out and is_contained(outcome):
+        return CheckResult(
+            "wallclock_enforced",
+            True,
+            f"killed at {outcome.wall_clock_s:.2f}s",
+            fields,
+        )
+    return CheckResult(
+        "wallclock_enforced",
+        False,
+        f"not timed out: timed_out={outcome.timed_out}",
+        fields,
+    )
+
+
+CHECKS = [
+    check_backend_available,
+    check_configure_succeeds,
+    check_benign_payload,
+    check_execve_denied,
+    check_wallclock_enforced,
+]
+
+
+def build_manifest(results: list[CheckResult]) -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "host": {
+            "hostname": socket.gethostname(),
+            "platform": platform.platform(),
+            "python": sys.version.split()[0],
+        },
+        "summary": {
+            "total": len(results),
+            "passed": sum(1 for r in results if r.passed),
+            "failed": sum(1 for r in results if not r.passed),
+        },
+        "checks": [asdict(r) for r in results],
+    }
+
+
+def main() -> int:
+    print("[verify] Running VAREK Guardrails verification battery...")
+    results: list[CheckResult] = []
+    for check_fn in CHECKS:
+        try:
+            r = check_fn()
+        except Exception as exc:  # noqa: BLE001 — record uncaught failures
+            r = CheckResult(check_fn.__name__, False, f"uncaught: {exc!r}")
+        marker = "PASS" if r.passed else "FAIL"
+        print(f"  [{marker}] {r.name}: {r.detail}")
+        results.append(r)
+
+    manifest = build_manifest(results)
+    summary = manifest["summary"]
+
+    print(
+        f"\n[verify] {summary['passed']}/{summary['total']} passed "
+        f"({summary['failed']} failed)"
+    )
+
+    # Persist the manifest to a tempfile so wandb.Artifact can include it.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        manifest_path = Path(tmpdir) / "verification_manifest.json"
+        manifest_path.write_text(json.dumps(manifest, indent=2))
+
+        run = wandb.init(
+            project=PROJECT,
+            entity=ENTITY,
+            job_type="verification",
+            config={"manifest_schema": manifest["schema_version"]},
+        )
+        try:
+            artifact = wandb.Artifact(
+                name="varek-guardrails-verification",
+                type="verification-report",
+                description=(
+                    "Structured manifest of VAREK Guardrails public-API "
+                    "verification checks executed against a live host."
+                ),
+                metadata=summary,
+            )
+            artifact.add_file(str(manifest_path), name="manifest.json")
+            run.log_artifact(artifact)
+            run.summary["verification/passed"] = summary["passed"]
+            run.summary["verification/failed"] = summary["failed"]
+            run.summary["verification/all_green"] = summary["failed"] == 0
+            print(f"[verify] Artifact logged to run {run.url}")
+        finally:
+            run.finish()
+
+    return 0 if summary["failed"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this example demonstrates

This example shows how to verify that AI/ML pipeline code is being executed under deterministic kernel-level isolation (seccomp-bpf + cgroups + wallclock), with all results logged to W&B for audit and reproducibility.

[VAREK Guardrails](https://github.com/kwdoug63/varek) is an open-source runtime sandbox that wraps `subprocess.Popen` with a seccomp-bpf filter, a cgroups v2 subtree (memory/CPU/PIDs), and a wallclock killer. This integration demonstrates three patterns that map directly to W&B-supported workflows.

## What's included

examples/varek-guardrails/
├── README.md
├── requirements.txt
├── verification_artifact.py    # 5-test verification battery → W&B Artifact
├── telemetry_stream.py         # subscribe_telemetry → W&B run logs
├── benchmark_suite.py          # 8-payload regression suite → W&B Table
└── scripts/
└── with-cgroup.sh          # idempotent cgroup subtree wrapper

## Why W&B users benefit

For teams running untrusted-code execution (LLM agents, eval harnesses, code-as-data pipelines), this provides a verifiable audit trail: every claim about isolation is backed by a logged run, and the runs are reproducible by any reviewer with the same versions installed. The Artifact pattern lets downstream stages depend on the verification result; the Table pattern catches policy regressions automatically.

## Tested against

- `varek-guardrails` 1.1.1
- `wandb` 0.26.1
- `weave` 0.50+
- Ubuntu 24.04 (Linux 6.x, cgroups v2)

## Live verification runs

End-to-end runs from the development environment (sober-agents entity):

| Script | Run | Result |
|---|---|---|
| `verification_artifact.py` | [fast-jazz-2](https://wandb.ai/sober-agents/varek-guardrails-verification/runs/tmictnq8) | 5/5 PASS, artifact logged |
| `telemetry_stream.py` | [skilled-bird-2](https://wandb.ai/sober-agents/varek-guardrails-telemetry/runs/tnqt8565) | 3 payloads, ~2475 audit events captured |
| `benchmark_suite.py` | [fluent-butterfly-2](https://wandb.ai/sober-agents/varek-guardrails-benchmarks/runs/yxu7w9o7) | 8/8 OK, match_rate=100% |

## Notes for reviewers

- Requires Linux with cgroups v2 (kernel 4.5+, all major distros from 2019 onward)
- The wrapper script (`scripts/with-cgroup.sh`) is required because systemd's `Delegate=` directive does not apply to `.slice` units, so cgroup subtree controls must be set explicitly before invocation
- The benchmark suite includes a `known_allowance` category for `os.system` passthrough — preserved deliberately as a regression test against future policy tightening in varek_guardrails
- The telemetry callback uses a PID guard + `queue.Queue` buffer to remain safe in post-fork-pre-exec contexts (audit hooks fire in forked children; calling `wandb.log` directly there breaks the seccomp arming)
- Directory placement (`examples/varek-guardrails/`) is a suggestion — happy to move under a different parent (e.g. `examples/security/` or `examples/integrations/`) based on maintainer preference

Happy to iterate on naming, scope, or any of the patterns.