### PR TITLE
Refactor the MNIST registry notebook for readability and usability

### DIFF
--- a/examples/marimo/mnist-registry/mnist_registry.md
+++ b/examples/marimo/mnist-registry/mnist_registry.md
@@ -26,46 +26,8 @@ header: |-
   """
 ---
 
-```python {.marimo hide_code="true"}
+```python {.marimo hide_code="true" name="setup"}
 import marimo as mo
-
-mo.md(
-    """
-    # MNIST -> W&B Run -> Registry
-
-    ## What you will build
-
-    - A **W&B run** with training and test metrics, gradient histograms,
-      and example test-set predictions logged as images.
-    - A **model Artifact** named `mnist-cnn-<run-id>` of type `model`,
-      carrying metadata (test accuracy, parameter count, hyperparameters).
-    - A version of that Artifact **linked into a W&B Registry collection**
-      so it appears under registered models org-wide.
-
-    ## Prerequisites
-
-    - Authenticate with W&B one of two ways: run **`wandb login`** in
-      your shell before starting marimo, or paste your key into the
-      **W&B API key** field in the form below. Get your key from
-      [wandb.ai/authorize](https://wandb.ai/authorize).
-    - A W&B **team** to write the run to, set in the **W&B entity** field.
-      Accounts created after May 2024 have no personal entity, so the run
-      must go to a team — your username will not work as an entity.
-    - A **W&B Registry** must exist in your org, and your account needs at
-      least the **Member** role on it (linking an artifact is a write
-      action). The built-in Model registry is provisioned automatically in
-      newer orgs. If linking fails (for example, from a view-only seat),
-      the run still completes and the Registry step explains how to fix it.
-    - A GPU is optional. The defaults finish in about 2 minutes on CPU.
-    """
-)
-```
-
-```python {.marimo}
-# Imports, device detection, and the input form all live in one cell: this
-# is "everything up to collecting your inputs". It defines the form widgets
-# but never reads their `.value` — marimo only makes a widget reactive when
-# a *different* cell consumes it, which the training cell below does.
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -91,62 +53,143 @@ else:
         "hyperparameters this takes about 2 minutes."
     )
     device_kind = "warn"
+```
 
+# MNIST -> W&B Run -> Registry
+
+## What you will build
+
+- A **W&B run** with training and test metrics, gradient histograms,
+  and example test-set predictions logged as images.
+- A **model Artifact** named `mnist-cnn-<run-id>` of type `model`,
+  carrying metadata (test accuracy, parameter count, hyperparameters).
+- A version of that Artifact **linked into a W&B Registry collection**
+  so it appears under registered models org-wide.
+
+## Prerequisites
+
+- Authenticate with W&B one of two ways: run **`wandb login`** in
+  your shell before starting marimo, or paste your key into the
+  **W&B API key** field in the form below. Get your key from
+  [wandb.ai/authorize](https://wandb.ai/authorize).
+- A W&B **team** to write the run to, set in the **W&B entity** field.
+  Accounts created after May 2024 have no personal entity, so the run
+  must go to a team — your username will not work as an entity.
+- A **W&B Registry** must exist in your org, and your account needs at
+  least the **Member** role on it (linking an artifact is a write
+  action). The built-in Model registry is provisioned automatically in
+  newer orgs. If linking fails (for example, from a view-only seat),
+  the run still completes and the Registry step explains how to fix it.
+- A GPU is optional. The defaults finish in about 2 minutes on CPU.
+
+```python {.marimo}
+mo.outline()
+```
+
+```python {.marimo hide_code="true"}
+mo.callout(
+    mo.md(f"**Device:** `{device}`. {device_note}"),
+    kind=device_kind,
+)
+```
+
+## Configuration
+
+Set the hyperparameters and W&B targets, then click **Train model** below.
+
+```python {.marimo hide_code="true"}
 epochs = mo.ui.slider(start=1, stop=10, step=1, value=3, label="Epochs")
 batch_size = mo.ui.dropdown(
     options=["32", "64", "128", "256"], value="64", label="Batch size"
 )
 lr = mo.ui.slider(
-    start=0.001, stop=0.1, step=0.001, value=0.01, label="Learning rate", show_value=True
+    start=0.001,
+    stop=0.1,
+    step=0.001,
+    value=0.01,
+    label="Learning rate",
+    show_value=True,
 )
 momentum = mo.ui.slider(
-    start=0.0, stop=0.99, step=0.01, value=0.5, label="SGD momentum", show_value=True
+    start=0.0,
+    stop=0.99,
+    step=0.01,
+    value=0.5,
+    label="SGD momentum",
+    show_value=True,
 )
 seed = mo.ui.number(start=0, stop=99999, value=42, label="Random seed")
 
 project = mo.ui.text(value="marimo-mnist-registry", label="W&B project")
 entity = mo.ui.text(
-    value="", label="W&B entity — a team you belong to (blank uses your default)"
+    value="",
+    label="W&B entity \u2014 a team you belong to (blank uses your default)",
 )
 run_name = mo.ui.text(value="", label="Run name (blank auto-generates)")
 api_key = mo.ui.text(
-    value="", kind="password", label="W&B API key (blank uses your shell login)"
+    value="",
+    kind="password",
+    label="W&B API key (blank uses your shell login)",
 )
 
 registry_name = mo.ui.text(value="model", label="W&B Registry name")
-collection_name = mo.ui.text(value="MNIST Classifiers", label="Registry collection")
-link_to_registry = mo.ui.checkbox(value=True, label="Link artifact to Registry")
-
-form = mo.vstack(
-    [
-        mo.md("### Training"),
-        mo.hstack([epochs, batch_size]),
-        mo.hstack([lr, momentum]),
-        seed,
-        mo.md("### W&B run"),
-        api_key,
-        mo.hstack([project, entity, run_name]),
-        mo.md("### Registry"),
-        mo.hstack([registry_name, collection_name, link_to_registry]),
-    ]
+collection_name = mo.ui.text(
+    value="MNIST Classifiers", label="Registry collection"
+)
+link_to_registry = mo.ui.checkbox(
+    value=True, label="Link artifact to Registry"
 )
 
-mo.vstack(
-    [
-        mo.callout(
-            mo.md(f"**Device:** `{device}` &mdash; {device_note}"), kind=device_kind
-        ),
-        mo.md(
-            "## Configure\n\nSet the hyperparameters and W&B targets, then click "
-            "**Train model** below. Changing a value here never starts a run on "
-            "its own — only the button does."
-        ),
-        form,
-    ]
+# Batch every control into one form so training only kicks off on submit.
+# `form.value` is None until the user clicks Train model, then becomes a dict
+# keyed by the names below \u2014 the training cell gates on that.
+form = (
+    mo.md(
+        """
+        **Training.**
+
+        {epochs}  {batch_size}
+
+        {lr}  {momentum}
+
+        {seed}
+
+        **W&B run.**
+
+        {api_key}
+
+        {project}
+
+        {entity}
+
+        {run_name}
+
+        **Registry.**
+
+        {registry_name}  {collection_name}  {link_to_registry}
+        """
+    )
+    .batch(
+        epochs=epochs,
+        batch_size=batch_size,
+        lr=lr,
+        momentum=momentum,
+        seed=seed,
+        api_key=api_key,
+        project=project,
+        entity=entity,
+        run_name=run_name,
+        registry_name=registry_name,
+        collection_name=collection_name,
+        link_to_registry=link_to_registry,
+    )
+    .form(submit_button_label="Train model", bordered=False)
 )
+
+form
 ```
 
-```python {.marimo}
+```python {.marimo name="Net"}
 class Net(nn.Module):
     """Small CNN: 2 conv layers (10, 20 filters, 5x5) + 2 FC (50, 10).
 
@@ -172,56 +215,56 @@ class Net(nn.Module):
         return F.log_softmax(x, dim=1)
 ```
 
+## Training
+
 ```python {.marimo}
-# Everything the Train button triggers, in one cell — no reason to make you
-# advance through a chain of output-less code blocks. Each milestone is
-# streamed to the cell output with `mo.output.append` as it happens.
 mo.stop(
-    not train_button.value,
+    form.value is None,
     mo.md(
-        "This cell runs the whole pipeline — start the run, train, log "
-        "metrics and example predictions, save the model Artifact, and link "
-        "it to the Registry. Click **Train model** below to run it."
+        "Training hasn't started yet. Fill in the form above and click "
+        "**Train model** to start the run — it trains the model, logs metrics "
+        "and example predictions, saves the weights as an Artifact, and links "
+        "them to the Registry."
     ),
 )
 
+cfg = form.value
 config = {
-    "epochs": epochs.value,
-    "batch_size": int(batch_size.value),
-    "lr": lr.value,
-    "momentum": momentum.value,
-    "seed": seed.value,
+    "epochs": cfg["epochs"],
+    "batch_size": int(cfg["batch_size"]),
+    "lr": cfg["lr"],
+    "momentum": cfg["momentum"],
+    "seed": cfg["seed"],
     "architecture": "CNN",
     "dataset": "MNIST",
 }
-registry_name_v = registry_name.value.strip()
-collection_name_v = collection_name.value.strip()
+registry_name_v = cfg["registry_name"].strip()
+collection_name_v = cfg["collection_name"].strip()
 
-# Authenticate. Finish any prior run first (marimo keeps the kernel alive
-# across re-clicks). A key pasted into the form wins; otherwise fall back to
-# ambient login (shell `wandb login`, WANDB_API_KEY, or netrc). The key is
-# never written to the run config.
+# Authenticate and start the run. Finish any prior run first (marimo keeps the
+# kernel alive across re-submits). A key pasted into the form wins; otherwise
+# fall back to ambient login (shell `wandb login`, WANDB_API_KEY, or netrc).
+# The key is never written to the run config.
 if wandb.run is not None:
     wandb.finish()
-if api_key.value:
-    wandb.login(key=api_key.value)
-
+if cfg["api_key"]:
+    wandb.login(key=cfg["api_key"])
 torch.manual_seed(config["seed"])
 
 try:
     run = wandb.init(
-        project=project.value or None,
-        entity=entity.value or None,
-        name=run_name.value or None,
+        project=cfg["project"] or None,
+        entity=cfg["entity"] or None,
+        name=cfg["run_name"] or None,
         config=config,
         job_type="train",
     )
-except Exception as exc:  # noqa: BLE001 - turn the raw traceback into guidance
+except Exception as init_exc:  # noqa: BLE001 - turn the raw traceback into guidance
     mo.stop(
         True,
         mo.callout(
             mo.md(
-                f"**Could not start the run.** `{exc}`\n\n"
+                f"**Could not start the run.** `{init_exc}`\n\n"
                 f"An `entity ... not found` error means the **W&B entity** is "
                 f"not a team you can write to. Personal-username entities were "
                 f"removed for accounts created after 21 May 2024, so set the "
@@ -231,40 +274,230 @@ except Exception as exc:  # noqa: BLE001 - turn the raw traceback into guidance
             kind="danger",
         ),
     )
+
 # Use `epoch` as the x-axis for train/test metrics in the W&B UI.
 wandb.define_metric("epoch")
 wandb.define_metric("train/*", step_metric="epoch")
 wandb.define_metric("test/*", step_metric="epoch")
+```
+
+```python {.marimo hide_code="true"}
 # Surface the run link right away so you can watch metrics stream live.
-mo.output.append(mo.md(f"**Run started:** [`{run.name}`]({run.url})"))
+mo.md(f"**Run started:** [`{run.name}`]({run.url})")
+```
 
-model = Net().to(device)
-# `log="gradients"` is the standard choice; `log="all"` also logs parameter
-# histograms at extra cost.
-wandb.watch(model, log="gradients", log_freq=100)
-optimizer = optim.SGD(
-    model.parameters(), lr=config["lr"], momentum=config["momentum"]
+```python {.marimo}
+train_ds, test_ds = load_data()
+model, history, final_acc, best_acc = run_training(
+    run, config, train_ds, test_ds
 )
 
-transform = transforms.Compose(
-    [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
+mo.vstack(
+    [
+        mo.md("### Training summary"),
+        mo.ui.table(history, selection=None),
+        mo.md(f"**Final test accuracy:** {final_acc:.2%}"),
+    ]
 )
-train_ds = datasets.MNIST("./data", train=True, download=True, transform=transform)
-test_ds = datasets.MNIST("./data", train=False, download=True, transform=transform)
-loader_kwargs = (
-    {"num_workers": 2, "pin_memory": True} if device.type == "cuda" else {}
-)
-train_loader = DataLoader(
-    train_ds, batch_size=config["batch_size"], shuffle=True, **loader_kwargs
-)
-test_loader = DataLoader(test_ds, batch_size=1000, shuffle=False, **loader_kwargs)
+```
 
-history = []
-best_acc = 0.0
-for epoch in range(1, config["epochs"] + 1):
+```python {.marimo}
+logged, artifact_name = save_and_log_artifact(
+    run,
+    model,
+    config,
+    train_size=len(train_ds),
+    test_size=len(test_ds),
+    final_acc=final_acc,
+    best_acc=best_acc,
+)
+
+# Link to the Registry unless disabled, capturing the outcome for display
+# rather than crashing the pipeline.
+if not cfg["link_to_registry"]:
+    registry_status = {"kind": "disabled"}
+else:
+    try:
+        registry_status = {
+            "kind": "linked",
+            "target_path": link_artifact_to_registry(
+                run, logged, registry_name_v, collection_name_v
+            ),
+        }
+    except Exception as link_exc:  # noqa: BLE001 - surface any failure to the reader
+        registry_status = {
+            "kind": "failed",
+            "target_path": f"wandb-registry-{registry_name_v}/{collection_name_v}",
+            "error": str(link_exc),
+        }
+
+# Close the run so its summary and any Registry link finalize server-side.
+wandb.finish()
+```
+
+```python {.marimo hide_code="true"}
+def _registry_callout(status):
+    if status["kind"] == "disabled":
+        return mo.md(
+            "_Registry linking is disabled — the artifact is logged to the run "
+            "but not linked to a collection._"
+        )
+    if status["kind"] == "linked":
+        return mo.callout(
+            mo.md(
+                f"**Linked to Registry:** `{status['target_path']}` — see "
+                f"[wandb.ai/registry](https://wandb.ai/registry)."
+            ),
+            kind="success",
+        )
+    return mo.callout(
+        mo.md(
+            f"**Registry link failed.** Target `{status['target_path']}` — "
+            f"`{status['error']}`\n\n"
+            f"- Linking needs at least the **Member** role on the "
+            f"Registry. `view-only member cannot write to project` means "
+            f"your seat is view-only: the run and artifact succeed, but "
+            f"linking is blocked. An admin can grant access from the "
+            f"Registry **Members** settings, the Python SDK "
+            f"(`wandb.Api().registry(...)` then `add_member()` / "
+            f"`update_member()`), or SCIM (`PATCH /scim/Users/{{id}}` with "
+            f"`registryRoles`) — see "
+            f"https://docs.wandb.ai/guides/registry/configure_registry/. "
+            f"Or set **W&B entity** to a team in an org where you have "
+            f"Registry write access.\n"
+            f"- The Registry `{registry_name_v}` may not exist; an admin "
+            f"can create it from the W&B Registry UI.\n"
+            f"- On the legacy Model Registry, link with "
+            f"`target_path='model-registry/{collection_name_v}'` instead."
+        ),
+        kind="danger",
+    )
+
+
+mo.vstack(
+    [
+        mo.md(f"**Artifact logged:** `{artifact_name}` (alias `latest`)"),
+        _registry_callout(registry_status),
+    ]
+)
+```
+
+## Evaluation
+
+```python {.marimo}
+api = wandb.Api()
+try:
+    consumed = api.artifact(
+        f"wandb-registry-{registry_name_v}/{collection_name_v}:latest",
+        type="model",
+    )
+    source = f"registry `wandb-registry-{registry_name_v}/{collection_name_v}:latest`"
+except Exception:  # noqa: BLE001 - registry link may be absent (e.g. a view-only seat)
+    consumed = api.artifact(
+        f"{run.entity}/{run.project}/{artifact_name}:latest",
+        type="model",
+    )
+    source = f"run artifact `{artifact_name}:latest`"
+weights_dir = consumed.download()
+
+clf = Net()
+clf.load_state_dict(
+    torch.load(f"{weights_dir}/mnist_cnn.pt", map_location="cpu")
+)
+clf.eval()
+
+rows = []
+n_correct = 0
+with torch.no_grad():
+    for i in range(10):
+        image, true_label = test_ds[i]
+        prediction = clf(image.unsqueeze(0)).argmax(dim=1).item()
+        n_correct += int(prediction == true_label)
+        # Undo the Normalize transform so the digit renders as a clean image.
+        digit = (image * 0.3081 + 0.1307).clamp(0, 1).squeeze().numpy()
+        rows.append(
+            {
+                "Image": mo.image(digit, width=56, vmin=0, vmax=1),
+                "Label": true_label,
+                "Prediction": prediction,
+            }
+        )
+
+mo.vstack(
+    [
+        mo.md(
+            f"**Classify 10 test digits.** Consumed the model from {source}, "
+            f"loaded the weights into a fresh network, and ran it on 10 held-out "
+            f"MNIST test images — **{n_correct}/10 correct**."
+        ),
+        mo.ui.table(rows, selection=None),
+    ]
+)
+```
+
+## Verify and next steps
+
+1. Open the run: [{run.name}]({run.url}) — check the **Charts**,
+   **System**, and **Examples** panels.
+2. In the run's **Artifacts** tab, confirm `mnist-cnn-{run.id}` is listed
+   with its metadata (test accuracy, parameter count, hyperparameters).
+3. At [wandb.ai/registry](https://wandb.ai/registry), open the
+   **{registry_name_v.title()}** registry, then the **{collection_name_v}**
+   collection, and confirm the linked version.
+
+**Consume the registered model** from any script or notebook:
+
+```python
+import wandb
+art = wandb.Api().artifact(
+    "wandb-registry-{registry_name_v}/{collection_name_v}:latest"
+)
+art.download()  # writes mnist_cnn.pt under ./artifacts/
+```
+
+**Next steps:** promote a version by adding the `production` alias from
+the Registry UI; re-run with a deeper architecture or a different
+learning rate and compare runs in the W&B UI; or add a W&B Automation to
+trigger evaluation when a new version is linked.
+<!---->
+## Helper functions
+
+```python {.marimo name="load_data"}
+def load_data():
+    """Download (or reuse cached) MNIST with the standard normalization."""
+    transform = transforms.Compose(
+        [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
+    )
+    train_ds = datasets.MNIST(
+        "./data", train=True, download=True, transform=transform
+    )
+    test_ds = datasets.MNIST(
+        "./data", train=False, download=True, transform=transform
+    )
+    return train_ds, test_ds
+```
+
+```python {.marimo name="make_loaders"}
+def make_loaders(train_ds, test_ds, batch_size):
+    """Wrap the datasets in loaders, enabling CUDA niceties when available."""
+    loader_kwargs = (
+        {"num_workers": 2, "pin_memory": True} if device.type == "cuda" else {}
+    )
+    train_loader = DataLoader(
+        train_ds, batch_size=batch_size, shuffle=True, **loader_kwargs
+    )
+    test_loader = DataLoader(
+        test_ds, batch_size=1000, shuffle=False, **loader_kwargs
+    )
+    return train_loader, test_loader
+```
+
+```python {.marimo name="train_one_epoch"}
+def train_one_epoch(model, loader, optimizer, epoch, epochs):
+    """Run one training epoch, streaming train loss to W&B every 50 steps."""
     model.train()
     for batch_idx, (data, target) in enumerate(
-        tqdm(train_loader, desc=f"epoch {epoch}/{config['epochs']}")
+        tqdm(loader, desc=f"epoch {epoch}/{epochs}")
     ):
         data, target = data.to(device), target.to(device)
         optimizer.zero_grad()
@@ -274,20 +507,26 @@ for epoch in range(1, config["epochs"] + 1):
         optimizer.step()
         if batch_idx % 50 == 0:
             wandb.log({"train/loss": loss.item(), "epoch": epoch})
+```
 
+```python {.marimo name="evaluate"}
+def evaluate(model, loader, max_examples=16):
+    """Compute test loss/accuracy and collect a few labelled example images."""
     model.eval()
     test_loss = 0.0
     correct = 0
     example_images = []
     with torch.no_grad():
-        for data, target in test_loader:
+        for data, target in loader:
             data, target = data.to(device), target.to(device)
             output = model(data)
             test_loss += F.nll_loss(output, target, reduction="sum").item()
             pred = output.argmax(dim=1, keepdim=True)
             correct += pred.eq(target.view_as(pred)).sum().item()
-            # Pull up to 16 example predictions from the first batch.
-            while len(example_images) < 16 and len(example_images) < data.size(0):
+            # Pull up to `max_examples` predictions for the W&B Examples panel.
+            while len(example_images) < max_examples and len(
+                example_images
+            ) < data.size(0):
                 j = len(example_images)
                 example_images.append(
                     wandb.Image(
@@ -295,216 +534,89 @@ for epoch in range(1, config["epochs"] + 1):
                         caption=f"pred={pred[j].item()} true={target[j].item()}",
                     )
                 )
-
-    test_loss /= len(test_loader.dataset)
-    test_acc = correct / len(test_loader.dataset)
-    best_acc = max(best_acc, test_acc)
-    wandb.log(
-        {
-            "test/loss": test_loss,
-            "test/accuracy": test_acc,
-            "epoch": epoch,
-            "examples": example_images,
-        }
-    )
-    history.append(
-        {"epoch": epoch, "test_loss": round(test_loss, 4), "test_acc": round(test_acc, 4)}
-    )
-
-# Full-precision last-epoch accuracy; `history` rounds only for display.
-final_acc = test_acc
-mo.output.append(
-    mo.vstack(
-        [
-            mo.md("### Training summary"),
-            mo.ui.table(history, selection=None),
-            mo.md(f"**Final test accuracy:** {final_acc:.2%}"),
-        ]
-    )
-)
-
-# Save the weights and log them as a model Artifact tagged `latest`.
-model_path = "mnist_cnn.pt"
-torch.save(model.state_dict(), model_path)
-artifact = wandb.Artifact(
-    name=f"mnist-cnn-{run.id}",
-    type="model",
-    description=(
-        "Small CNN trained on MNIST. Architecture: 2 conv layers "
-        "(10 and 20 filters, 5x5 kernels) + 2 FC layers (50, 10)."
-    ),
-    metadata={
-        "framework": "pytorch",
-        "architecture": "CNN",
-        "num_parameters": sum(p.numel() for p in model.parameters()),
-        "dataset": "MNIST",
-        "train_size": len(train_ds),
-        "test_size": len(test_ds),
-        "test_accuracy": final_acc,
-        "best_test_accuracy": best_acc,
-        "hyperparameters": dict(config),
-    },
-)
-artifact.add_file(model_path)
-logged = run.log_artifact(artifact, aliases=["latest"])
-# Block until the artifact has committed before linking, to avoid a race.
-logged.wait()
-mo.output.append(mo.md(f"**Artifact logged:** `{artifact.name}` (alias `latest`)"))
-
-# Link to the Registry, surfacing a remediation note instead of crashing.
-if link_to_registry.value:
-    target_path = f"wandb-registry-{registry_name_v}/{collection_name_v}"
-    try:
-        run.link_artifact(artifact=logged, target_path=target_path)
-        mo.output.append(
-            mo.callout(
-                mo.md(
-                    f"**Linked to Registry:** `{target_path}` — see "
-                    f"[wandb.ai/registry](https://wandb.ai/registry)."
-                ),
-                kind="success",
-            )
-        )
-    except Exception as exc:  # noqa: BLE001 - surface any failure to the reader
-        mo.output.append(
-            mo.callout(
-                mo.md(
-                    f"**Registry link failed.** Target `{target_path}` — `{exc}`\n\n"
-                    f"- Linking needs at least the **Member** role on the "
-                    f"Registry. `view-only member cannot write to project` means "
-                    f"your seat is view-only: the run and artifact succeed, but "
-                    f"linking is blocked. An admin can grant access from the "
-                    f"Registry **Members** settings, the Python SDK "
-                    f"(`wandb.Api().registry(...)` then `add_member()` / "
-                    f"`update_member()`), or SCIM (`PATCH /scim/Users/{{id}}` with "
-                    f"`registryRoles`) — see "
-                    f"https://docs.wandb.ai/guides/registry/configure_registry/. "
-                    f"Or set **W&B entity** to a team in an org where you have "
-                    f"Registry write access.\n"
-                    f"- The Registry `{registry_name_v}` may not exist; an admin "
-                    f"can create it from the W&B Registry UI.\n"
-                    f"- On the legacy Model Registry, link with "
-                    f"`target_path='model-registry/{collection_name_v}'` instead."
-                ),
-                kind="danger",
-            )
-        )
-else:
-    mo.output.append(
-        mo.md(
-            "_Registry linking is disabled — the artifact is logged to the run "
-            "but not linked to a collection._"
-        )
-    )
-
-# Close the run so its summary and any Registry link finalize server-side.
-wandb.finish()
+    n = len(loader.dataset)
+    return test_loss / n, correct / n, example_images
 ```
 
-```python {.marimo}
-# Placed after the training cell on purpose: it's the explicit "run" trigger
-# for the pipeline above. It must be its own cell because that cell reads
-# `train_button.value`, and a widget only drives reactivity when a
-# *different* cell consumes it. The gate also stops the pipeline from
-# running automatically when the notebook opens; run_button's value is True
-# only for the cascade a click triggers (then resets to False), so editing
-# the form afterwards re-runs the training cell but it stops immediately.
-train_button = mo.ui.run_button(label="Train model", kind="success")
-mo.vstack(
-    [
-        train_button,
-        mo.md(
-            "Runs the training cell above. It is gated so it does not "
-            "execute when the notebook opens — click to run, and click "
-            "again to retrain after editing the form (the previous run is "
-            "finished first)."
+```python {.marimo name="run_training"}
+def run_training(run, config, train_ds, test_ds):
+    """Train the CNN, logging metrics each epoch; return the model and history."""
+    train_loader, test_loader = make_loaders(
+        train_ds, test_ds, config["batch_size"]
+    )
+    model = Net().to(device)
+    # `log="gradients"` is the standard choice; `log="all"` also logs parameter
+    # histograms at extra cost.
+    wandb.watch(model, log="gradients", log_freq=100)
+    optimizer = optim.SGD(
+        model.parameters(), lr=config["lr"], momentum=config["momentum"]
+    )
+
+    history = []
+    best_acc = 0.0
+    test_acc = 0.0
+    for epoch in range(1, config["epochs"] + 1):
+        train_one_epoch(model, train_loader, optimizer, epoch, config["epochs"])
+        test_loss, test_acc, example_images = evaluate(model, test_loader)
+        best_acc = max(best_acc, test_acc)
+        wandb.log(
+            {
+                "test/loss": test_loss,
+                "test/accuracy": test_acc,
+                "epoch": epoch,
+                "examples": example_images,
+            }
+        )
+        history.append(
+            {
+                "epoch": epoch,
+                "test_loss": round(test_loss, 4),
+                "test_acc": round(test_acc, 4),
+            }
+        )
+    # Full-precision last-epoch accuracy; `history` rounds only for display.
+    return model, history, test_acc, best_acc
+```
+
+```python {.marimo name="save_and_log_artifact"}
+def save_and_log_artifact(
+    run, model, config, train_size, test_size, final_acc, best_acc,
+    model_path="mnist_cnn.pt",
+):
+    """Persist the weights and log them as a `model` Artifact aliased `latest`."""
+    torch.save(model.state_dict(), model_path)
+    name = f"mnist-cnn-{run.id}"
+    artifact = wandb.Artifact(
+        name=name,
+        type="model",
+        description=(
+            "Small CNN trained on MNIST. Architecture: 2 conv layers "
+            "(10 and 20 filters, 5x5 kernels) + 2 FC layers (50, 10)."
         ),
-    ]
-)
+        metadata={
+            "framework": "pytorch",
+            "architecture": "CNN",
+            "num_parameters": sum(p.numel() for p in model.parameters()),
+            "dataset": "MNIST",
+            "train_size": train_size,
+            "test_size": test_size,
+            "test_accuracy": final_acc,
+            "best_test_accuracy": best_acc,
+            "hyperparameters": dict(config),
+        },
+    )
+    artifact.add_file(model_path)
+    logged = run.log_artifact(artifact, aliases=["latest"])
+    # Block until the artifact has committed before linking, to avoid a race.
+    logged.wait()
+    # Return the base name (no version) so callers can build `<name>:latest`.
+    return logged, name
 ```
 
-```python {.marimo}
-# Consume the model: download it from W&B (preferring the registered
-# version, falling back to the run's own artifact), load the weights into a
-# fresh network, and classify 10 held-out test digits.
-api = wandb.Api()
-try:
-    consumed = api.artifact(
-        f"wandb-registry-{registry_name_v}/{collection_name_v}:latest", type="model"
-    )
-    source = f"registry `wandb-registry-{registry_name_v}/{collection_name_v}:latest`"
-except Exception:  # noqa: BLE001 - registry link may be absent (e.g. a view-only seat)
-    consumed = api.artifact(
-        f"{run.entity}/{run.project}/mnist-cnn-{run.id}:latest", type="model"
-    )
-    source = f"run artifact `mnist-cnn-{run.id}:latest`"
-weights_dir = consumed.download()
-
-clf = Net()
-clf.load_state_dict(torch.load(f"{weights_dir}/mnist_cnn.pt", map_location="cpu"))
-clf.eval()
-
-cards = []
-n_correct = 0
-with torch.no_grad():
-    for i in range(10):
-        image, true_label = test_ds[i]
-        prediction = clf(image.unsqueeze(0)).argmax(dim=1).item()
-        n_correct += int(prediction == true_label)
-        # Undo the Normalize transform so the digit renders as a clean image.
-        digit = (image * 0.3081 + 0.1307).clamp(0, 1).squeeze().numpy()
-        mark = "✅" if prediction == true_label else "❌"
-        cards.append(
-            mo.vstack(
-                [
-                    mo.image(digit, width=64, vmin=0, vmax=1),
-                    mo.md(f"{mark} **{prediction}** · true {true_label}"),
-                ],
-                align="center",
-            )
-        )
-
-mo.vstack(
-    [
-        mo.md(
-            f"## Classify 10 test digits\n\nConsumed the model from {source}, "
-            f"loaded the weights into a fresh network, and ran it on 10 held-out "
-            f"MNIST test images — **{n_correct}/10 correct**."
-        ),
-        mo.hstack(cards, wrap=True, justify="start"),
-    ]
-)
+```python {.marimo name="link_artifact_to_registry"}
+def link_artifact_to_registry(run, logged, registry_name, collection_name):
+    """Link the logged artifact into a Registry collection; return the target."""
+    target_path = f"wandb-registry-{registry_name}/{collection_name}"
+    run.link_artifact(artifact=logged, target_path=target_path)
+    return target_path
 ```
-
-````python {.marimo hide_code="true"}
-# Renders only after a run exists (it consumes `run` from the training
-# cell), so it appears once training finishes.
-mo.md(
-    f"""
-    ## Verify and next steps
-
-    1. Open the run: [{run.name}]({run.url}) — check the **Charts**,
-       **System**, and **Examples** panels.
-    2. In the run's **Artifacts** tab, confirm `mnist-cnn-{run.id}` is listed
-       with its metadata (test accuracy, parameter count, hyperparameters).
-    3. At [wandb.ai/registry](https://wandb.ai/registry), open the
-       **{registry_name_v.title()}** registry, then the **{collection_name_v}**
-       collection, and confirm the linked version.
-
-    **Consume the registered model** from any script or notebook:
-
-    ```python
-    import wandb
-    art = wandb.Api().artifact(
-        "wandb-registry-{registry_name_v}/{collection_name_v}:latest"
-    )
-    art.download()  # writes mnist_cnn.pt under ./artifacts/
-    ```
-
-    **Next steps:** promote a version by adding the `production` alias from
-    the Registry UI; re-run with a deeper architecture or a different
-    learning rate and compare runs in the W&B UI; or add a W&B Automation to
-    trigger evaluation when a new version is linked.
-    """
-)
-````

--- a/examples/marimo/mnist-registry/mnist_registry.py
+++ b/examples/marimo/mnist-registry/mnist_registry.py
@@ -22,53 +22,11 @@ runs as a single step, so one click trains, logs, saves, and registers.
 
 import marimo
 
-__generated_with = "0.23.9"
+__generated_with = "0.23.11"
 app = marimo.App(width="medium", app_title="MNIST -> W&B Registry")
 
-
-@app.cell(hide_code=True)
-def _():
+with app.setup(hide_code=True):
     import marimo as mo
-
-    mo.md(
-        """
-        # MNIST -> W&B Run -> Registry
-
-        ## What you will build
-
-        - A **W&B run** with training and test metrics, gradient histograms,
-          and example test-set predictions logged as images.
-        - A **model Artifact** named `mnist-cnn-<run-id>` of type `model`,
-          carrying metadata (test accuracy, parameter count, hyperparameters).
-        - A version of that Artifact **linked into a W&B Registry collection**
-          so it appears under registered models org-wide.
-
-        ## Prerequisites
-
-        - Authenticate with W&B one of two ways: run **`wandb login`** in
-          your shell before starting marimo, or paste your key into the
-          **W&B API key** field in the form below. Get your key from
-          [wandb.ai/authorize](https://wandb.ai/authorize).
-        - A W&B **team** to write the run to, set in the **W&B entity** field.
-          Accounts created after May 2024 have no personal entity, so the run
-          must go to a team — your username will not work as an entity.
-        - A **W&B Registry** must exist in your org, and your account needs at
-          least the **Member** role on it (linking an artifact is a write
-          action). The built-in Model registry is provisioned automatically in
-          newer orgs. If linking fails (for example, from a view-only seat),
-          the run still completes and the Registry step explains how to fix it.
-        - A GPU is optional. The defaults finish in about 2 minutes on CPU.
-        """
-    )
-    return (mo,)
-
-
-@app.cell
-def _(mo):
-    # Imports, device detection, and the input form all live in one cell: this
-    # is "everything up to collecting your inputs". It defines the form widgets
-    # but never reads their `.value` — marimo only makes a widget reactive when
-    # a *different* cell consumes it, which the training cell below does.
     import torch
     import torch.nn as nn
     import torch.nn.functional as F
@@ -95,189 +53,242 @@ def _(mo):
         )
         device_kind = "warn"
 
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    # MNIST -> W&B Run -> Registry
+
+    ## What you will build
+
+    - A **W&B run** with training and test metrics, gradient histograms,
+      and example test-set predictions logged as images.
+    - A **model Artifact** named `mnist-cnn-<run-id>` of type `model`,
+      carrying metadata (test accuracy, parameter count, hyperparameters).
+    - A version of that Artifact **linked into a W&B Registry collection**
+      so it appears under registered models org-wide.
+
+    ## Prerequisites
+
+    - Authenticate with W&B one of two ways: run **`wandb login`** in
+      your shell before starting marimo, or paste your key into the
+      **W&B API key** field in the form below. Get your key from
+      [wandb.ai/authorize](https://wandb.ai/authorize).
+    - A W&B **team** to write the run to, set in the **W&B entity** field.
+      Accounts created after May 2024 have no personal entity, so the run
+      must go to a team — your username will not work as an entity.
+    - A **W&B Registry** must exist in your org, and your account needs at
+      least the **Member** role on it (linking an artifact is a write
+      action). The built-in Model registry is provisioned automatically in
+      newer orgs. If linking fails (for example, from a view-only seat),
+      the run still completes and the Registry step explains how to fix it.
+    - A GPU is optional. The defaults finish in about 2 minutes on CPU.
+    """)
+    return
+
+
+@app.cell
+def _():
+    mo.outline()
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.callout(
+        mo.md(f"**Device:** `{device}`. {device_note}"),
+        kind=device_kind,
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ## Configuration
+
+    Set the hyperparameters and W&B targets, then click **Train model** below.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _():
     epochs = mo.ui.slider(start=1, stop=10, step=1, value=3, label="Epochs")
     batch_size = mo.ui.dropdown(
         options=["32", "64", "128", "256"], value="64", label="Batch size"
     )
     lr = mo.ui.slider(
-        start=0.001, stop=0.1, step=0.001, value=0.01, label="Learning rate", show_value=True
+        start=0.001,
+        stop=0.1,
+        step=0.001,
+        value=0.01,
+        label="Learning rate",
+        show_value=True,
     )
     momentum = mo.ui.slider(
-        start=0.0, stop=0.99, step=0.01, value=0.5, label="SGD momentum", show_value=True
+        start=0.0,
+        stop=0.99,
+        step=0.01,
+        value=0.5,
+        label="SGD momentum",
+        show_value=True,
     )
     seed = mo.ui.number(start=0, stop=99999, value=42, label="Random seed")
 
     project = mo.ui.text(value="marimo-mnist-registry", label="W&B project")
     entity = mo.ui.text(
-        value="", label="W&B entity — a team you belong to (blank uses your default)"
+        value="",
+        label="W&B entity \u2014 a team you belong to (blank uses your default)",
     )
     run_name = mo.ui.text(value="", label="Run name (blank auto-generates)")
     api_key = mo.ui.text(
-        value="", kind="password", label="W&B API key (blank uses your shell login)"
+        value="",
+        kind="password",
+        label="W&B API key (blank uses your shell login)",
     )
 
     registry_name = mo.ui.text(value="model", label="W&B Registry name")
-    collection_name = mo.ui.text(value="MNIST Classifiers", label="Registry collection")
-    link_to_registry = mo.ui.checkbox(value=True, label="Link artifact to Registry")
-
-    form = mo.vstack(
-        [
-            mo.md("### Training"),
-            mo.hstack([epochs, batch_size]),
-            mo.hstack([lr, momentum]),
-            seed,
-            mo.md("### W&B run"),
-            api_key,
-            mo.hstack([project, entity, run_name]),
-            mo.md("### Registry"),
-            mo.hstack([registry_name, collection_name, link_to_registry]),
-        ]
+    collection_name = mo.ui.text(
+        value="MNIST Classifiers", label="Registry collection"
+    )
+    link_to_registry = mo.ui.checkbox(
+        value=True, label="Link artifact to Registry"
     )
 
-    mo.vstack(
-        [
-            mo.callout(
-                mo.md(f"**Device:** `{device}` &mdash; {device_note}"), kind=device_kind
-            ),
-            mo.md(
-                "## Configure\n\nSet the hyperparameters and W&B targets, then click "
-                "**Train model** below. Changing a value here never starts a run on "
-                "its own — only the button does."
-            ),
-            form,
-        ]
-    )
-    return (
-        DataLoader,
-        F,
-        api_key,
-        batch_size,
-        collection_name,
-        datasets,
-        device,
-        entity,
-        epochs,
-        link_to_registry,
-        lr,
-        momentum,
-        nn,
-        optim,
-        project,
-        registry_name,
-        run_name,
-        seed,
-        torch,
-        tqdm,
-        transforms,
-        wandb,
-    )
-
-
-@app.cell
-def _(F, nn):
-    class Net(nn.Module):
-        """Small CNN: 2 conv layers (10, 20 filters, 5x5) + 2 FC (50, 10).
-
-        Defined in its own cell so the training cell and the consume cell can
-        share it (marimo forbids defining the same name in two cells).
-        """
-
-        def __init__(self):
-            super().__init__()
-            self.conv1 = nn.Conv2d(1, 10, kernel_size=5)
-            self.conv2 = nn.Conv2d(10, 20, kernel_size=5)
-            self.conv2_drop = nn.Dropout2d()
-            self.fc1 = nn.Linear(320, 50)
-            self.fc2 = nn.Linear(50, 10)
-
-        def forward(self, x):
-            x = F.relu(F.max_pool2d(self.conv1(x), 2))
-            x = F.relu(F.max_pool2d(self.conv2_drop(self.conv2(x)), 2))
-            x = x.view(-1, 320)
-            x = F.relu(self.fc1(x))
-            x = F.dropout(x, training=self.training)
-            x = self.fc2(x)
-            return F.log_softmax(x, dim=1)
-
-    return (Net,)
-
-
-@app.cell
-def _(
-    DataLoader,
-    F,
-    Net,
-    api_key,
-    batch_size,
-    collection_name,
-    datasets,
-    device,
-    entity,
-    epochs,
-    link_to_registry,
-    lr,
-    momentum,
-    mo,
-    optim,
-    project,
-    registry_name,
-    run_name,
-    seed,
-    torch,
-    tqdm,
-    train_button,
-    transforms,
-    wandb,
-):
-    # Everything the Train button triggers, in one cell — no reason to make you
-    # advance through a chain of output-less code blocks. Each milestone is
-    # streamed to the cell output with `mo.output.append` as it happens.
-    mo.stop(
-        not train_button.value,
+    # Batch every control into one form so training only kicks off on submit.
+    # `form.value` is None until the user clicks Train model, then becomes a dict
+    # keyed by the names below \u2014 the training cell gates on that.
+    form = (
         mo.md(
-            "This cell runs the whole pipeline — start the run, train, log "
-            "metrics and example predictions, save the model Artifact, and link "
-            "it to the Registry. Click **Train model** below to run it."
+            """
+            **Training.**
+
+            {epochs}  {batch_size}
+
+            {lr}  {momentum}
+
+            {seed}
+
+            **W&B run.**
+
+            {api_key}
+
+            {project}
+
+            {entity}
+
+            {run_name}
+
+            **Registry.**
+
+            {registry_name}  {collection_name}  {link_to_registry}
+            """
+        )
+        .batch(
+            epochs=epochs,
+            batch_size=batch_size,
+            lr=lr,
+            momentum=momentum,
+            seed=seed,
+            api_key=api_key,
+            project=project,
+            entity=entity,
+            run_name=run_name,
+            registry_name=registry_name,
+            collection_name=collection_name,
+            link_to_registry=link_to_registry,
+        )
+        .form(submit_button_label="Train model", bordered=False)
+    )
+
+    form
+    return (form,)
+
+
+@app.class_definition
+class Net(nn.Module):
+    """Small CNN: 2 conv layers (10, 20 filters, 5x5) + 2 FC (50, 10).
+
+    Defined in its own cell so the training cell and the consume cell can
+    share it (marimo forbids defining the same name in two cells).
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.conv1 = nn.Conv2d(1, 10, kernel_size=5)
+        self.conv2 = nn.Conv2d(10, 20, kernel_size=5)
+        self.conv2_drop = nn.Dropout2d()
+        self.fc1 = nn.Linear(320, 50)
+        self.fc2 = nn.Linear(50, 10)
+
+    def forward(self, x):
+        x = F.relu(F.max_pool2d(self.conv1(x), 2))
+        x = F.relu(F.max_pool2d(self.conv2_drop(self.conv2(x)), 2))
+        x = x.view(-1, 320)
+        x = F.relu(self.fc1(x))
+        x = F.dropout(x, training=self.training)
+        x = self.fc2(x)
+        return F.log_softmax(x, dim=1)
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md("""
+    ## Training
+    """)
+    return
+
+
+@app.cell
+def _(form):
+    mo.stop(
+        form.value is None,
+        mo.md(
+            "Training hasn't started yet. Fill in the form above and click "
+            "**Train model** to start the run — it trains the model, logs metrics "
+            "and example predictions, saves the weights as an Artifact, and links "
+            "them to the Registry."
         ),
     )
 
+    cfg = form.value
     config = {
-        "epochs": epochs.value,
-        "batch_size": int(batch_size.value),
-        "lr": lr.value,
-        "momentum": momentum.value,
-        "seed": seed.value,
+        "epochs": cfg["epochs"],
+        "batch_size": int(cfg["batch_size"]),
+        "lr": cfg["lr"],
+        "momentum": cfg["momentum"],
+        "seed": cfg["seed"],
         "architecture": "CNN",
         "dataset": "MNIST",
     }
-    registry_name_v = registry_name.value.strip()
-    collection_name_v = collection_name.value.strip()
+    registry_name_v = cfg["registry_name"].strip()
+    collection_name_v = cfg["collection_name"].strip()
 
-    # Authenticate. Finish any prior run first (marimo keeps the kernel alive
-    # across re-clicks). A key pasted into the form wins; otherwise fall back to
-    # ambient login (shell `wandb login`, WANDB_API_KEY, or netrc). The key is
-    # never written to the run config.
+    # Authenticate and start the run. Finish any prior run first (marimo keeps the
+    # kernel alive across re-submits). A key pasted into the form wins; otherwise
+    # fall back to ambient login (shell `wandb login`, WANDB_API_KEY, or netrc).
+    # The key is never written to the run config.
     if wandb.run is not None:
         wandb.finish()
-    if api_key.value:
-        wandb.login(key=api_key.value)
-
+    if cfg["api_key"]:
+        wandb.login(key=cfg["api_key"])
     torch.manual_seed(config["seed"])
 
     try:
         run = wandb.init(
-            project=project.value or None,
-            entity=entity.value or None,
-            name=run_name.value or None,
+            project=cfg["project"] or None,
+            entity=cfg["entity"] or None,
+            name=cfg["run_name"] or None,
             config=config,
             job_type="train",
         )
-    except Exception as exc:  # noqa: BLE001 - turn the raw traceback into guidance
+    except Exception as init_exc:  # noqa: BLE001 - turn the raw traceback into guidance
         mo.stop(
             True,
             mo.callout(
                 mo.md(
-                    f"**Could not start the run.** `{exc}`\n\n"
+                    f"**Could not start the run.** `{init_exc}`\n\n"
                     f"An `entity ... not found` error means the **W&B entity** is "
                     f"not a team you can write to. Personal-username entities were "
                     f"removed for accounts created after 21 May 2024, so set the "
@@ -287,13 +298,316 @@ def _(
                 kind="danger",
             ),
         )
+
     # Use `epoch` as the x-axis for train/test metrics in the W&B UI.
     wandb.define_metric("epoch")
     wandb.define_metric("train/*", step_metric="epoch")
     wandb.define_metric("test/*", step_metric="epoch")
-    # Surface the run link right away so you can watch metrics stream live.
-    mo.output.append(mo.md(f"**Run started:** [`{run.name}`]({run.url})"))
+    return cfg, collection_name_v, config, registry_name_v, run
 
+
+@app.cell(hide_code=True)
+def _(run):
+    # Surface the run link right away so you can watch metrics stream live.
+    mo.md(f"**Run started:** [`{run.name}`]({run.url})")
+    return
+
+
+@app.cell
+def _(config, run):
+    train_ds, test_ds = load_data()
+    model, history, final_acc, best_acc = run_training(
+        run, config, train_ds, test_ds
+    )
+
+    mo.vstack(
+        [
+            mo.md("### Training summary"),
+            mo.ui.table(history, selection=None),
+            mo.md(f"**Final test accuracy:** {final_acc:.2%}"),
+        ]
+    )
+    return best_acc, final_acc, model, test_ds, train_ds
+
+
+@app.cell
+def _(
+    best_acc,
+    cfg,
+    collection_name_v,
+    config,
+    final_acc,
+    model,
+    registry_name_v,
+    run,
+    test_ds,
+    train_ds,
+):
+    logged, artifact_name = save_and_log_artifact(
+        run,
+        model,
+        config,
+        train_size=len(train_ds),
+        test_size=len(test_ds),
+        final_acc=final_acc,
+        best_acc=best_acc,
+    )
+
+    # Link to the Registry unless disabled, capturing the outcome for display
+    # rather than crashing the pipeline.
+    if not cfg["link_to_registry"]:
+        registry_status = {"kind": "disabled"}
+    else:
+        try:
+            registry_status = {
+                "kind": "linked",
+                "target_path": link_artifact_to_registry(
+                    run, logged, registry_name_v, collection_name_v
+                ),
+            }
+        except Exception as link_exc:  # noqa: BLE001 - surface any failure to the reader
+            registry_status = {
+                "kind": "failed",
+                "target_path": f"wandb-registry-{registry_name_v}/{collection_name_v}",
+                "error": str(link_exc),
+            }
+
+    # Close the run so its summary and any Registry link finalize server-side.
+    wandb.finish()
+    return artifact_name, registry_status
+
+
+@app.cell(hide_code=True)
+def _(artifact_name, collection_name_v, registry_name_v, registry_status):
+    def _registry_callout(status):
+        if status["kind"] == "disabled":
+            return mo.md(
+                "_Registry linking is disabled — the artifact is logged to the run "
+                "but not linked to a collection._"
+            )
+        if status["kind"] == "linked":
+            return mo.callout(
+                mo.md(
+                    f"**Linked to Registry:** `{status['target_path']}` — see "
+                    f"[wandb.ai/registry](https://wandb.ai/registry)."
+                ),
+                kind="success",
+            )
+        return mo.callout(
+            mo.md(
+                f"**Registry link failed.** Target `{status['target_path']}` — "
+                f"`{status['error']}`\n\n"
+                f"- Linking needs at least the **Member** role on the "
+                f"Registry. `view-only member cannot write to project` means "
+                f"your seat is view-only: the run and artifact succeed, but "
+                f"linking is blocked. An admin can grant access from the "
+                f"Registry **Members** settings, the Python SDK "
+                f"(`wandb.Api().registry(...)` then `add_member()` / "
+                f"`update_member()`), or SCIM (`PATCH /scim/Users/{{id}}` with "
+                f"`registryRoles`) — see "
+                f"https://docs.wandb.ai/guides/registry/configure_registry/. "
+                f"Or set **W&B entity** to a team in an org where you have "
+                f"Registry write access.\n"
+                f"- The Registry `{registry_name_v}` may not exist; an admin "
+                f"can create it from the W&B Registry UI.\n"
+                f"- On the legacy Model Registry, link with "
+                f"`target_path='model-registry/{collection_name_v}'` instead."
+            ),
+            kind="danger",
+        )
+
+
+    mo.vstack(
+        [
+            mo.md(f"**Artifact logged:** `{artifact_name}` (alias `latest`)"),
+            _registry_callout(registry_status),
+        ]
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md("""
+    ## Evaluation
+    """)
+    return
+
+
+@app.cell
+def _(artifact_name, collection_name_v, registry_name_v, run, test_ds):
+    api = wandb.Api()
+    try:
+        consumed = api.artifact(
+            f"wandb-registry-{registry_name_v}/{collection_name_v}:latest",
+            type="model",
+        )
+        source = f"registry `wandb-registry-{registry_name_v}/{collection_name_v}:latest`"
+    except Exception:  # noqa: BLE001 - registry link may be absent (e.g. a view-only seat)
+        consumed = api.artifact(
+            f"{run.entity}/{run.project}/{artifact_name}:latest",
+            type="model",
+        )
+        source = f"run artifact `{artifact_name}:latest`"
+    weights_dir = consumed.download()
+
+    clf = Net()
+    clf.load_state_dict(
+        torch.load(f"{weights_dir}/mnist_cnn.pt", map_location="cpu")
+    )
+    clf.eval()
+
+    rows = []
+    n_correct = 0
+    with torch.no_grad():
+        for i in range(10):
+            image, true_label = test_ds[i]
+            prediction = clf(image.unsqueeze(0)).argmax(dim=1).item()
+            n_correct += int(prediction == true_label)
+            # Undo the Normalize transform so the digit renders as a clean image.
+            digit = (image * 0.3081 + 0.1307).clamp(0, 1).squeeze().numpy()
+            rows.append(
+                {
+                    "Image": mo.image(digit, width=56, vmin=0, vmax=1),
+                    "Label": true_label,
+                    "Prediction": prediction,
+                }
+            )
+
+    mo.vstack(
+        [
+            mo.md(
+                f"**Classify 10 test digits.** Consumed the model from {source}, "
+                f"loaded the weights into a fresh network, and ran it on 10 held-out "
+                f"MNIST test images — **{n_correct}/10 correct**."
+            ),
+            mo.ui.table(rows, selection=None),
+        ]
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ## Verify and next steps
+
+    1. Open the run: [{run.name}]({run.url}) — check the **Charts**,
+       **System**, and **Examples** panels.
+    2. In the run's **Artifacts** tab, confirm `mnist-cnn-{run.id}` is listed
+       with its metadata (test accuracy, parameter count, hyperparameters).
+    3. At [wandb.ai/registry](https://wandb.ai/registry), open the
+       **{registry_name_v.title()}** registry, then the **{collection_name_v}**
+       collection, and confirm the linked version.
+
+    **Consume the registered model** from any script or notebook:
+
+    ```python
+    import wandb
+    art = wandb.Api().artifact(
+        "wandb-registry-{registry_name_v}/{collection_name_v}:latest"
+    )
+    art.download()  # writes mnist_cnn.pt under ./artifacts/
+    ```
+
+    **Next steps:** promote a version by adding the `production` alias from
+    the Registry UI; re-run with a deeper architecture or a different
+    learning rate and compare runs in the W&B UI; or add a W&B Automation to
+    trigger evaluation when a new version is linked.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ## Helper functions
+    """)
+    return
+
+
+@app.function
+def load_data():
+    """Download (or reuse cached) MNIST with the standard normalization."""
+    transform = transforms.Compose(
+        [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
+    )
+    train_ds = datasets.MNIST(
+        "./data", train=True, download=True, transform=transform
+    )
+    test_ds = datasets.MNIST(
+        "./data", train=False, download=True, transform=transform
+    )
+    return train_ds, test_ds
+
+
+@app.function
+def make_loaders(train_ds, test_ds, batch_size):
+    """Wrap the datasets in loaders, enabling CUDA niceties when available."""
+    loader_kwargs = (
+        {"num_workers": 2, "pin_memory": True} if device.type == "cuda" else {}
+    )
+    train_loader = DataLoader(
+        train_ds, batch_size=batch_size, shuffle=True, **loader_kwargs
+    )
+    test_loader = DataLoader(
+        test_ds, batch_size=1000, shuffle=False, **loader_kwargs
+    )
+    return train_loader, test_loader
+
+
+@app.function
+def train_one_epoch(model, loader, optimizer, epoch, epochs):
+    """Run one training epoch, streaming train loss to W&B every 50 steps."""
+    model.train()
+    for batch_idx, (data, target) in enumerate(
+        tqdm(loader, desc=f"epoch {epoch}/{epochs}")
+    ):
+        data, target = data.to(device), target.to(device)
+        optimizer.zero_grad()
+        output = model(data)
+        loss = F.nll_loss(output, target)
+        loss.backward()
+        optimizer.step()
+        if batch_idx % 50 == 0:
+            wandb.log({"train/loss": loss.item(), "epoch": epoch})
+
+
+@app.function
+def evaluate(model, loader, max_examples=16):
+    """Compute test loss/accuracy and collect a few labelled example images."""
+    model.eval()
+    test_loss = 0.0
+    correct = 0
+    example_images = []
+    with torch.no_grad():
+        for data, target in loader:
+            data, target = data.to(device), target.to(device)
+            output = model(data)
+            test_loss += F.nll_loss(output, target, reduction="sum").item()
+            pred = output.argmax(dim=1, keepdim=True)
+            correct += pred.eq(target.view_as(pred)).sum().item()
+            # Pull up to `max_examples` predictions for the W&B Examples panel.
+            while len(example_images) < max_examples and len(
+                example_images
+            ) < data.size(0):
+                j = len(example_images)
+                example_images.append(
+                    wandb.Image(
+                        data[j],
+                        caption=f"pred={pred[j].item()} true={target[j].item()}",
+                    )
+                )
+    n = len(loader.dataset)
+    return test_loss / n, correct / n, example_images
+
+
+@app.function
+def run_training(run, config, train_ds, test_ds):
+    """Train the CNN, logging metrics each epoch; return the model and history."""
+    train_loader, test_loader = make_loaders(
+        train_ds, test_ds, config["batch_size"]
+    )
     model = Net().to(device)
     # `log="gradients"` is the standard choice; `log="all"` also logs parameter
     # histograms at extra cost.
@@ -302,58 +616,12 @@ def _(
         model.parameters(), lr=config["lr"], momentum=config["momentum"]
     )
 
-    transform = transforms.Compose(
-        [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
-    )
-    train_ds = datasets.MNIST("./data", train=True, download=True, transform=transform)
-    test_ds = datasets.MNIST("./data", train=False, download=True, transform=transform)
-    loader_kwargs = (
-        {"num_workers": 2, "pin_memory": True} if device.type == "cuda" else {}
-    )
-    train_loader = DataLoader(
-        train_ds, batch_size=config["batch_size"], shuffle=True, **loader_kwargs
-    )
-    test_loader = DataLoader(test_ds, batch_size=1000, shuffle=False, **loader_kwargs)
-
     history = []
     best_acc = 0.0
+    test_acc = 0.0
     for epoch in range(1, config["epochs"] + 1):
-        model.train()
-        for batch_idx, (data, target) in enumerate(
-            tqdm(train_loader, desc=f"epoch {epoch}/{config['epochs']}")
-        ):
-            data, target = data.to(device), target.to(device)
-            optimizer.zero_grad()
-            output = model(data)
-            loss = F.nll_loss(output, target)
-            loss.backward()
-            optimizer.step()
-            if batch_idx % 50 == 0:
-                wandb.log({"train/loss": loss.item(), "epoch": epoch})
-
-        model.eval()
-        test_loss = 0.0
-        correct = 0
-        example_images = []
-        with torch.no_grad():
-            for data, target in test_loader:
-                data, target = data.to(device), target.to(device)
-                output = model(data)
-                test_loss += F.nll_loss(output, target, reduction="sum").item()
-                pred = output.argmax(dim=1, keepdim=True)
-                correct += pred.eq(target.view_as(pred)).sum().item()
-                # Pull up to 16 example predictions from the first batch.
-                while len(example_images) < 16 and len(example_images) < data.size(0):
-                    j = len(example_images)
-                    example_images.append(
-                        wandb.Image(
-                            data[j],
-                            caption=f"pred={pred[j].item()} true={target[j].item()}",
-                        )
-                    )
-
-        test_loss /= len(test_loader.dataset)
-        test_acc = correct / len(test_loader.dataset)
+        train_one_epoch(model, train_loader, optimizer, epoch, config["epochs"])
+        test_loss, test_acc, example_images = evaluate(model, test_loader)
         best_acc = max(best_acc, test_acc)
         wandb.log(
             {
@@ -364,26 +632,26 @@ def _(
             }
         )
         history.append(
-            {"epoch": epoch, "test_loss": round(test_loss, 4), "test_acc": round(test_acc, 4)}
+            {
+                "epoch": epoch,
+                "test_loss": round(test_loss, 4),
+                "test_acc": round(test_acc, 4),
+            }
         )
-
     # Full-precision last-epoch accuracy; `history` rounds only for display.
-    final_acc = test_acc
-    mo.output.append(
-        mo.vstack(
-            [
-                mo.md("### Training summary"),
-                mo.ui.table(history, selection=None),
-                mo.md(f"**Final test accuracy:** {final_acc:.2%}"),
-            ]
-        )
-    )
+    return model, history, test_acc, best_acc
 
-    # Save the weights and log them as a model Artifact tagged `latest`.
-    model_path = "mnist_cnn.pt"
+
+@app.function
+def save_and_log_artifact(
+    run, model, config, train_size, test_size, final_acc, best_acc,
+    model_path="mnist_cnn.pt",
+):
+    """Persist the weights and log them as a `model` Artifact aliased `latest`."""
     torch.save(model.state_dict(), model_path)
+    name = f"mnist-cnn-{run.id}"
     artifact = wandb.Artifact(
-        name=f"mnist-cnn-{run.id}",
+        name=name,
         type="model",
         description=(
             "Small CNN trained on MNIST. Architecture: 2 conv layers "
@@ -394,8 +662,8 @@ def _(
             "architecture": "CNN",
             "num_parameters": sum(p.numel() for p in model.parameters()),
             "dataset": "MNIST",
-            "train_size": len(train_ds),
-            "test_size": len(test_ds),
+            "train_size": train_size,
+            "test_size": test_size,
             "test_accuracy": final_acc,
             "best_test_accuracy": best_acc,
             "hyperparameters": dict(config),
@@ -405,171 +673,16 @@ def _(
     logged = run.log_artifact(artifact, aliases=["latest"])
     # Block until the artifact has committed before linking, to avoid a race.
     logged.wait()
-    mo.output.append(mo.md(f"**Artifact logged:** `{artifact.name}` (alias `latest`)"))
-
-    # Link to the Registry, surfacing a remediation note instead of crashing.
-    if link_to_registry.value:
-        target_path = f"wandb-registry-{registry_name_v}/{collection_name_v}"
-        try:
-            run.link_artifact(artifact=logged, target_path=target_path)
-            mo.output.append(
-                mo.callout(
-                    mo.md(
-                        f"**Linked to Registry:** `{target_path}` — see "
-                        f"[wandb.ai/registry](https://wandb.ai/registry)."
-                    ),
-                    kind="success",
-                )
-            )
-        except Exception as exc:  # noqa: BLE001 - surface any failure to the reader
-            mo.output.append(
-                mo.callout(
-                    mo.md(
-                        f"**Registry link failed.** Target `{target_path}` — `{exc}`\n\n"
-                        f"- Linking needs at least the **Member** role on the "
-                        f"Registry. `view-only member cannot write to project` means "
-                        f"your seat is view-only: the run and artifact succeed, but "
-                        f"linking is blocked. An admin can grant access from the "
-                        f"Registry **Members** settings, the Python SDK "
-                        f"(`wandb.Api().registry(...)` then `add_member()` / "
-                        f"`update_member()`), or SCIM (`PATCH /scim/Users/{{id}}` with "
-                        f"`registryRoles`) — see "
-                        f"https://docs.wandb.ai/guides/registry/configure_registry/. "
-                        f"Or set **W&B entity** to a team in an org where you have "
-                        f"Registry write access.\n"
-                        f"- The Registry `{registry_name_v}` may not exist; an admin "
-                        f"can create it from the W&B Registry UI.\n"
-                        f"- On the legacy Model Registry, link with "
-                        f"`target_path='model-registry/{collection_name_v}'` instead."
-                    ),
-                    kind="danger",
-                )
-            )
-    else:
-        mo.output.append(
-            mo.md(
-                "_Registry linking is disabled — the artifact is logged to the run "
-                "but not linked to a collection._"
-            )
-        )
-
-    # Close the run so its summary and any Registry link finalize server-side.
-    wandb.finish()
-    return collection_name_v, registry_name_v, run, test_ds
+    # Return the base name (no version) so callers can build `<name>:latest`.
+    return logged, name
 
 
-@app.cell
-def _(mo):
-    # Placed after the training cell on purpose: it's the explicit "run" trigger
-    # for the pipeline above. It must be its own cell because that cell reads
-    # `train_button.value`, and a widget only drives reactivity when a
-    # *different* cell consumes it. The gate also stops the pipeline from
-    # running automatically when the notebook opens; run_button's value is True
-    # only for the cascade a click triggers (then resets to False), so editing
-    # the form afterwards re-runs the training cell but it stops immediately.
-    train_button = mo.ui.run_button(label="Train model", kind="success")
-    mo.vstack(
-        [
-            train_button,
-            mo.md(
-                "Runs the training cell above. It is gated so it does not "
-                "execute when the notebook opens — click to run, and click "
-                "again to retrain after editing the form (the previous run is "
-                "finished first)."
-            ),
-        ]
-    )
-    return (train_button,)
-
-
-@app.cell
-def _(Net, collection_name_v, mo, registry_name_v, run, test_ds, torch, wandb):
-    # Consume the model: download it from W&B (preferring the registered
-    # version, falling back to the run's own artifact), load the weights into a
-    # fresh network, and classify 10 held-out test digits.
-    api = wandb.Api()
-    try:
-        consumed = api.artifact(
-            f"wandb-registry-{registry_name_v}/{collection_name_v}:latest", type="model"
-        )
-        source = f"registry `wandb-registry-{registry_name_v}/{collection_name_v}:latest`"
-    except Exception:  # noqa: BLE001 - registry link may be absent (e.g. a view-only seat)
-        consumed = api.artifact(
-            f"{run.entity}/{run.project}/mnist-cnn-{run.id}:latest", type="model"
-        )
-        source = f"run artifact `mnist-cnn-{run.id}:latest`"
-    weights_dir = consumed.download()
-
-    clf = Net()
-    clf.load_state_dict(torch.load(f"{weights_dir}/mnist_cnn.pt", map_location="cpu"))
-    clf.eval()
-
-    cards = []
-    n_correct = 0
-    with torch.no_grad():
-        for i in range(10):
-            image, true_label = test_ds[i]
-            prediction = clf(image.unsqueeze(0)).argmax(dim=1).item()
-            n_correct += int(prediction == true_label)
-            # Undo the Normalize transform so the digit renders as a clean image.
-            digit = (image * 0.3081 + 0.1307).clamp(0, 1).squeeze().numpy()
-            mark = "✅" if prediction == true_label else "❌"
-            cards.append(
-                mo.vstack(
-                    [
-                        mo.image(digit, width=64, vmin=0, vmax=1),
-                        mo.md(f"{mark} **{prediction}** · true {true_label}"),
-                    ],
-                    align="center",
-                )
-            )
-
-    mo.vstack(
-        [
-            mo.md(
-                f"## Classify 10 test digits\n\nConsumed the model from {source}, "
-                f"loaded the weights into a fresh network, and ran it on 10 held-out "
-                f"MNIST test images — **{n_correct}/10 correct**."
-            ),
-            mo.hstack(cards, wrap=True, justify="start"),
-        ]
-    )
-    return
-
-
-@app.cell(hide_code=True)
-def _(collection_name_v, mo, registry_name_v, run):
-    # Renders only after a run exists (it consumes `run` from the training
-    # cell), so it appears once training finishes.
-    mo.md(
-        f"""
-        ## Verify and next steps
-
-        1. Open the run: [{run.name}]({run.url}) — check the **Charts**,
-           **System**, and **Examples** panels.
-        2. In the run's **Artifacts** tab, confirm `mnist-cnn-{run.id}` is listed
-           with its metadata (test accuracy, parameter count, hyperparameters).
-        3. At [wandb.ai/registry](https://wandb.ai/registry), open the
-           **{registry_name_v.title()}** registry, then the **{collection_name_v}**
-           collection, and confirm the linked version.
-
-        **Consume the registered model** from any script or notebook:
-
-        ```python
-        import wandb
-        art = wandb.Api().artifact(
-            "wandb-registry-{registry_name_v}/{collection_name_v}:latest"
-        )
-        art.download()  # writes mnist_cnn.pt under ./artifacts/
-        ```
-
-        **Next steps:** promote a version by adding the `production` alias from
-        the Registry UI; re-run with a deeper architecture or a different
-        learning rate and compare runs in the W&B UI; or add a W&B Automation to
-        trigger evaluation when a new version is linked.
-        """
-    )
-    return
+@app.function
+def link_artifact_to_registry(run, logged, registry_name, collection_name):
+    """Link the logged artifact into a Registry collection; return the target."""
+    target_path = f"wandb-registry-{registry_name}/{collection_name}"
+    run.link_artifact(artifact=logged, target_path=target_path)
+    return target_path
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR refactors the MNIST notebook. Changes include:

- Move imports and constants into a setup cell
- Wrap the UI elements in a submittable form, removing the
  ui.run_button()
- Refactor the monolithic training and logging cell into multiple helper
  functions, each declared in their own cell as a reusable function
- Separate logic cells from view cells when possible
- Clean up the evaluation presentation, using a table instead of
  markdown+emoji
- Add a mo.outline() so users can see an outline of the notebook at a
  glance

Basic principles:

  * Gate execution once on mo.stop(), then let the graph handle the
    rest. All other cells reference run/config, which don't exist
    until the form is submitted. This lets us remove lots of
    confusing conditions.
  * Separate logic from presentation
  * Push temporary variables into functions to reduce notebook globals.
    marimo notebooks work best when there are as few global variables
    as possible.