### PR TITLE
Harden shell quoting in Clean Notebooks workflow

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Commit and push if changed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           git config --global user.name 'GitHub Action'
           git config --global user.email 'action@github.com'
@@ -38,5 +39,5 @@ jobs:
             echo "No changes to commit"
           else
             git commit -m "Auto-clean notebooks"
-            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+            git push origin "HEAD:$HEAD_REF"
           fi


### PR DESCRIPTION
Route the interpolated `${{ ... }}` value in the *Clean Notebooks* workflow's commit-and-push step through an `env:` variable and reference it quoted, so it's treated as data rather than shell syntax. Defense-in-depth; no behavior change.

Internal tracking: [VULNMGMT-2001](https://coreweave.atlassian.net/browse/VULNMGMT-2001)


[VULNMGMT-2001]: https://coreweave.atlassian.net/browse/VULNMGMT-2001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ