### PR TITLE
Replace deprecated WANDB_LOG_MODEL=true with end in HF optimize notebook

### DIFF
--- a/colabs/huggingface/Optimize_Hugging_Face_models_with_Weights_&_Biases.ipynb
+++ b/colabs/huggingface/Optimize_Hugging_Face_models_with_Weights_&_Biases.ipynb
@@ -129,7 +129,7 @@
     "\n",
     "W&B integration with Hugging Face can be configured to add extra functionalities:\n",
     "\n",
-    "* auto-logging of models as artifacts: just set environment varilable `WANDB_LOG_MODEL` to `true`\n",
+    "* auto-logging of models as artifacts: just set environment variable `WANDB_LOG_MODEL` to `end` (or to `checkpoint` to also log every checkpoint)\n",
     "* log histograms of gradients and parameters: by default gradients are logged, you can also log parameters by setting environment variable `WANDB_WATCH` to `all`\n",
     "* set custom run names with `run_name` arg present in scripts or as part of `TrainingArguments`\n",
     "* organize runs by project with the `WANDB_PROJECT` environment variable\n",
@@ -150,7 +150,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%env WANDB_LOG_MODEL=true"
+    "%env WANDB_LOG_MODEL=end"
    ]
   },
   {


### PR DESCRIPTION
## Problem

`Optimize_Hugging_Face_models_with_Weights_&_Biases.ipynb` sets `%env WANDB_LOG_MODEL=true`. Modern `transformers` no longer accepts `true` — the `WandbLogModel` enum only accepts `end`, `checkpoint`, or `false`, so running the notebook crashes with:

```
ValueError: 'true' is not a valid WandbLogModel
```

(with a DeprecationWarning telling users to use `'end'` or `'checkpoint'` instead).

## Fix

- Code cell: `%env WANDB_LOG_MODEL=true` → `%env WANDB_LOG_MODEL=end`
- Markdown tip: updated to say set `WANDB_LOG_MODEL` to `end` (mentioning `checkpoint` as the alternative for per-checkpoint logging), and fixed the "varilable" typo on the same line

No other changes; the notebook JSON is otherwise untouched.

## Verification

Against the current `transformers` release in a fresh venv:

```
>>> WandbLogModel('end')         # ok
>>> WandbLogModel('checkpoint')  # ok
>>> WandbLogModel('true')        # raises, as reported in the issues
```

Notebook validated with `nbformat.validate(...)` (nbformat 4) — passes. `grep` confirms no remaining `WANDB_LOG_MODEL=true` in this notebook.

Fixes #572
Fixes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)