### PR TITLE
Update GitHub Actions to current majors across workflows

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -13,12 +13,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
       - name: Install Dependencies

--- a/.github/workflows/pr_reply1.yml
+++ b/.github/workflows/pr_reply1.yml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.9
     - name: Run script
@@ -22,7 +22,7 @@ jobs:
       run: |
         pip install -Uq ghapi nb_helpers
         python .github/scripts/pr_reply1.py
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: pr_comment
         path: modified_colabs.json

--- a/.github/workflows/pr_reply2.yml
+++ b/.github/workflows/pr_reply2.yml
@@ -13,10 +13,10 @@ jobs:
   download_payload:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.9
     - name: Run script


### PR DESCRIPTION
Addresses #625

Lands the three pending GitHub Actions major updates listed under "Pending Approval" on the Renovate Dependency Dashboard (`renovate/actions-checkout-7.x`, `renovate/actions-setup-python-6.x`, `renovate/major-github-artifact-actions`).

## Changes

| Workflow | Action | Before | After |
|---|---|---|---|
| `.github/workflows/cleanup.yml` | `actions/checkout` | v4 | v7 |
| `.github/workflows/cleanup.yml` | `actions/setup-python` | v5 | v6 |
| `.github/workflows/pr_reply1.yml` | `actions/checkout` | v3 | v7 |
| `.github/workflows/pr_reply1.yml` | `actions/setup-python` | v3 | v6 |
| `.github/workflows/pr_reply1.yml` | `actions/upload-artifact` | v4 | v7 |
| `.github/workflows/pr_reply2.yml` | `actions/checkout` | v3 | v7 |
| `.github/workflows/pr_reply2.yml` | `actions/setup-python` | v3 | v6 |

All target tags verified to exist via `gh api repos/actions/<name>/tags` (latest majors: checkout v7, setup-python v6, upload-artifact v7).

## Breaking-change review per action

- **actions/checkout v3/v4 → v7**
  - v5/v6 move to the Node 24 runtime (minimum runner 2.327.1 / 2.329.0). All three jobs run on GitHub-hosted `ubuntu-latest`, which satisfies this.
  - v6 persists credentials under `$RUNNER_TEMP` via a git config include instead of writing them into `.git/config`. The `git push` in `cleanup.yml` still authenticates through the include; the stricter runner requirement only affects Docker container actions, which these workflows do not use.
  - v7 adds a guard that refuses to check out fork-PR code on `pull_request_target`/`workflow_run` triggers unless `allow-unsafe-pr-checkout: true` is set. Verified against the v7 source (`src/unsafe-pr-checkout-helper.ts`): `pr_reply2.yml` (a `workflow_run` workflow) checks out with no `ref:`, which resolves to the base repo's default-branch head, so none of the guard's match conditions (fork repo name, `refs/pull/N/head|merge` ref, PR head SHA) fire. `cleanup.yml` triggers on `pull_request_review`, which the guard does not cover. No opt-in needed.
- **actions/setup-python v3/v5 → v6**: v6 moves to Node 24 (hosted runners fine). Python version resolution comes from the shared `python-versions` manifest, so `python-version: 3.9`/`3.11` behave the same. No renamed or removed inputs affect these workflows.
- **actions/upload-artifact v4 → v7**: v5/v6 move to Node 24; v7 adds opt-in direct uploads (`archive: false`) and ESM internals. The `name` + `path` usage here is unchanged, and the artifact backend is the same one v4 already used. The `pr_comment` artifact (`modified_colabs.json`) is still uploaded under the same name, and `pr_reply2.yml` retrieves it through the GitHub REST API via `nb_helpers`/`ghapi`, which is unaffected by the action version.

The cross-workflow artifact handoff (`pr_reply1.yml` uploads `pr_comment` → `pr_reply2.yml` downloads it via API in `.github/scripts/pr_reply2.py`) was reviewed end to end; naming and behavior line up after the bumps.

## Relationship to Renovate pin PR #624

Renovate's open PR #624 ("Pin dependencies") pins the current action versions to SHA digests, per the SHA-pinning config enabled in #623. This PR touches the same `uses:` lines, so the two conflict. Suggested order: merge this major-version bump first, then let Renovate rebase #624 (rebase checkbox on the dashboard), which will re-pin the new v7/v6/v7 versions to digests. That converges on digest-pinned current majors without hand-picking SHAs here.

## Validation

- `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"` → `yaml ok`
- `npx --yes --package renovate -- renovate-config-validator .github/renovate.json5` → `INFO: Config validated successfully against 1 file(s)`

## Note on the dashboard's "Repository problem"

The dashboard reports: "File contents are invalid JSONC but parse using JSON5." This repo's `.github/renovate.json5` is plain JSON and validates clean (see above), so the warning appears to originate from the shared preset it extends — `github>wandb/renovate-config` serves JSON5-style content from a `.json` file. That needs fixing in the `wandb/renovate-config` repo, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)