### PR TITLE
Add missing wandb Hydra config group to minimal-hydra-example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.swp
 .python-version
 wandb
+!examples/minimal-hydra-example/configs/wandb/
 wandb-debug.log
 __pycache__
 .ipynb_checkpoints

--- a/examples/minimal-hydra-example/configs/wandb/default.yaml
+++ b/examples/minimal-hydra-example/configs/wandb/default.yaml
@@ -1,0 +1,4 @@
+---
+setup:
+  project: example-hydra
+  entity: null


### PR DESCRIPTION
## Problem

Running the minimal Hydra example fails immediately at config composition:

```text
hydra.errors.MissingConfigException: In 'defaults': Could not find 'wandb/default'
```

`examples/minimal-hydra-example/configs/defaults.yaml` lists `- wandb: default` in its Hydra defaults, but the `configs/wandb/` directory does not exist in the repo.

### Root cause

The repo-root `.gitignore` contains a bare `wandb` pattern (line 3, intended for wandb run-output directories), which also matches `configs/wandb/` — `git check-ignore -v` confirms it. The config group was silently swallowed and never committed.

## Fix

1. **`examples/minimal-hydra-example/configs/wandb/default.yaml`** (new): defines the config group with a top-level `setup:` mapping, matching how it is consumed and documented:
   - `main.py` uses exactly one thing from this group: `wandb.init(**cfg.wandb.setup)`, so the group must be a mapping of valid `wandb.init` kwargs under `setup:`.
   - The README states the project is called `example-hydra` and documents overriding entity with `wandb.setup.entity=<entity_name>` (same override path used for `wandb_sweep.yaml`). Declaring `entity: null` is load-bearing: Hydra struct mode rejects overrides of keys that do not exist, so without it the documented override would fail. `entity=None` is `wandb.init`'s default (use your default entity).
   - File style matches the sibling group configs (leading `---` document marker, no `# @package` directive, same as `configs/model/default.yaml` and `configs/optimizer/*.yaml`).
2. **`.gitignore`**: adds `!examples/minimal-hydra-example/configs/wandb/` immediately after the `wandb` pattern so the config group cannot be silently re-lost (for example, a future `configs/wandb/offline.yaml` would otherwise be skipped by `git add` with no warning).

## Verification

Compose test (hydra-core 1.3.4 / omegaconf 2.3.1):

```python
from hydra import compose, initialize_config_dir
import os
cfg_dir = os.path.abspath("examples/minimal-hydra-example/configs")
with initialize_config_dir(version_base=None, config_dir=cfg_dir):
    cfg = compose(config_name="defaults")
    assert cfg.wandb.setup.project == "example-hydra"
    cfg2 = compose(config_name="defaults", overrides=["wandb.setup.entity=test-entity"])
    assert cfg2.wandb.setup.entity == "test-entity"
```

- **Before** this change: fails with `MissingConfigException: In 'defaults': Could not find 'wandb/default'` (the exact error from #482).
- **After**: both composes pass; composed group is `{'setup': {'project': 'example-hydra', 'entity': None}}`.
- Sanity check: `wandb.init(project="example-hydra", entity=None, mode="offline")` runs and finishes cleanly (wandb 0.26.1).

Fixes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)