### PR TITLE
Update code-saving notebook to use run.log_code

### DIFF
--- a/colabs/wandb-log/Saving_Code_with_W&B.ipynb
+++ b/colabs/wandb-log/Saving_Code_with_W&B.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "With Weights & Biases, you **won't need to worry** about that happening again!\n",
     "We'll **save the code you ran along with results and hyperparameters**, all in a centralized location with easy comparison and visualization tools.\n",
-    "Even better, in a Jupyter notebbok this feature **tracks all the cells you executed!**\n",
+    "Even better, in a Jupyter notebook this feature **tracks all the cells you executed!**\n",
     "\n",
     "Here is a simple implementation where we simulate logging some metrics and the code that generates them -- the same procedure works for both notebooks and Python scripts.\n",
     "\n",
@@ -110,11 +110,11 @@
     "with run:\n",
     "    for step in range(100):\n",
     "        # insert training process here\n",
-    "        wandb.log({\n",
+    "        run.log({\n",
     "            \"acc\": math.log(0.1 + random.random() + step * 0.01),\n",
     "            \"val_acc\": math.log(0.1 + random.random() + step * 0.01),\n",
-    "            \"loss\": wandb.config.hyperparameter - math.log(0.1 + random.random() + step * 0.01),\n",
-    "            \"val_loss\":  wandb.config.hyperparameter - math.log(0.1 + random.random() + step * 0.01)})"
+    "            \"loss\": run.config.hyperparameter - math.log(0.1 + random.random() + step * 0.01),\n",
+    "            \"val_loss\":  run.config.hyperparameter - math.log(0.1 + random.random() + step * 0.01)})"
    ]
   },
   {
@@ -137,10 +137,16 @@
    "source": [
     "# 💾 Logging Metrics and Saving Code\n",
     "\n",
-    "Adding code saving is easy: we just pass the argument\n",
-    "`save_code=True` to `wandb.init`. That's it!\n",
+    "To save code, we do two things:\n",
     "\n",
-    "_Hot Tip_: If you don't want to worry about setting this on every project,\n",
+    "1. Pass `save_code=True` to `wandb.init`. This turns on code saving for the run and, in a notebook, tells W&B to try to capture the notebook and the history of cells you executed in the session.\n",
+    "2. Call `run.log_code()` before the run finishes. This uploads a snapshot of your code -- the files that match the filter you pass (here, `.py` and `.ipynb` files), plus the notebook copy W&B stages in notebook sessions -- as a versioned code artifact. That artifact is what fills in the `{}` code viewer on the run page.\n",
+    "\n",
+    "Calling [`run.log_code`](https://docs.wandb.ai/models/ref/python/experiments/run/) is the most reliable way to make sure your code lands in W&B, whether you run a script, a Jupyter notebook, or Colab. In a script, you can also capture code automatically by passing `save_code=True` together with `settings=wandb.Settings(code_dir=\".\")` to `wandb.init`. See the [code saving docs](https://docs.wandb.ai/models/app/features/panels/code) for details.\n",
+    "\n",
+    "This time, we'll also let the run span two cells and close it explicitly with `run.finish()`. Whenever a cell executes while a run is active, W&B stages a copy of the notebook, so `run.log_code` can upload it even on platforms like Colab where the notebook file isn't sitting on disk.\n",
+    "\n",
+    "_Hot Tip_: If you don't want to worry about setting `save_code` on every project,\n",
     "just change your default on the [settings page](https://wandb.ai/settings), as below:"
    ]
   },
@@ -159,16 +165,27 @@
    "source": [
     "run = wandb.init(project=\"code_save\",\n",
     "                 config={\"hyperparameter\": 4},\n",
-    "                 save_code=True)\n",
+    "                 save_code=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for step in range(100):\n",
+    "    # insert training process here\n",
+    "    run.log({\n",
+    "        \"acc\": math.log(0.1 + random.random() + step * 0.01),\n",
+    "        \"val_acc\": math.log(0.1 + random.random() + step * 0.01),\n",
+    "        \"loss\": run.config.hyperparameter - math.log(0.1 + random.random() + step * 0.01),\n",
+    "        \"val_loss\":  run.config.hyperparameter - math.log(0.1 + random.random() + step * 0.01)})\n",
     "\n",
-    "with run:\n",
-    "    for step in range(100):\n",
-    "        # insert training process here\n",
-    "        wandb.log({\n",
-    "            \"acc\": math.log(0.1 + random.random() + step * 0.01),\n",
-    "            \"val_acc\": math.log(0.1 + random.random() + step * 0.01),\n",
-    "            \"loss\": wandb.config.hyperparameter - math.log(0.1 + random.random() + step * 0.01),\n",
-    "            \"val_loss\":  wandb.config.hyperparameter - math.log(0.1 + random.random() + step * 0.01)})"
+    "# upload a snapshot of our code to the run as a code artifact\n",
+    "run.log_code(include_fn=lambda path: path.endswith(\".py\") or path.endswith(\".ipynb\"))\n",
+    "\n",
+    "run.finish()"
    ]
   },
   {
@@ -186,7 +203,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you click it, you'll see the entire history of the notebook session! That includes the code we ran for the section without code logging.\n",
+    "If you click it, you'll see the code that was saved for this run: the files uploaded by `run.log_code` and, in a notebook, the history of the cells executed in the session -- including the ones we ran for the section without code saving.\n",
     "\n",
     "W&B also automatically catches the standard out and standard error,\n",
     "plus system metrics!\n"


### PR DESCRIPTION
## Why

The `Saving_Code_with_W&B.ipynb` colab demonstrated code saving solely through `wandb.init(..., save_code=True)`, telling readers "That's it!". As reported in #591, running the notebook today does not produce the `{}` code panel on the run page: `save_code=True` alone only enables W&B's automatic capture paths, and in notebook environments (Colab, Jupyter, VS Code) those paths depend on W&B being able to locate the notebook file, which is not reliable across platforms (see the same snippet failing on some platforms in [this W&B community thread](https://community.wandb.ai/t/saving-code-not-working-in-notebook-on-some-platforms/6452)).

Current W&B docs recommend explicitly calling `run.log_code()`, which uploads a versioned `code`-type artifact that populates the code viewer:

- [Save and diff code](https://docs.wandb.ai/models/app/features/panels/code) - "use `wandb.Run.log_code()`" for fine-grained capture; `wandb.Settings(code_dir=".")` for automatic capture
- [`Run.log_code` reference](https://docs.wandb.ai/models/ref/python/experiments/run/)

## What changed

- The "with code" example now calls `run.log_code(include_fn=lambda path: path.endswith(".py") or path.endswith(".ipynb"))` before `run.finish()`, keeping `save_code=True` in `wandb.init`.
- The example is split into an init cell and a train/log_code/finish cell, so cells execute while the run is active and W&B's notebook hook can stage a copy of the notebook for `run.log_code` to upload (this is what makes capture work on Colab, where the notebook file is not on disk).
- Rewrote the "just pass `save_code=True`... That's it!" markdown to describe the two-step approach, and noted that scripts can alternatively use `save_code=True` with `settings=wandb.Settings(code_dir=".")` (per the SDK, `code_dir` only takes effect when `save_code` is enabled).
- Updated both training loops to the current `run.log`/`run.config` API for consistency; fixed a "notebbok" typo. Screenshots are unchanged and still accurate: the second run still produces the `{}` panel, the first still does not.

## Verification (offline, wandb 0.26.1)

Extracted the notebook's code cells into a script and ran the full flow with `WANDB_MODE=offline`, then inspected the offline run directories and `.wandb` transaction logs:

- Old approach (`save_code=True` only): run files contain a copy of the main script under `files/code/`, but **zero artifact records** - nothing to populate the current `{}` code viewer, and in notebook environments even the main-file copy depends on the flaky notebook-discovery path.
- Updated approach: same run files, **plus** a `code`-type artifact (`source-code_save-...`) whose manifest contains both the `.py` file and the `.ipynb` file picked up by the `include_fn`.
- The `save_code=False` run logs no code in either form, matching the notebook's "without code" section.

All 17 cells validate with `nbformat`, and every code cell parses with `ast.parse`. Edits were made as targeted string edits on the raw JSON, so the notebook formatting is untouched for the post-approval auto-clean workflow.

Fixes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)